### PR TITLE
Set default assignee to logged in user on task list

### DIFF
--- a/system/modules/task/actions/tasklist.php
+++ b/system/modules/task/actions/tasklist.php
@@ -9,7 +9,7 @@ function tasklist_ALL(Web $w) {
 	$is_closed = 0;
     if (empty($reset)) {
         // Get filter values
-        $assignee_id = $w->sessionOrRequest("task__assignee-id");
+        $assignee_id = $w->sessionOrRequest("task__assignee-id", $w->Auth->user()->id);
         $creator_id = $w->sessionOrRequest("task__creator-id");
 
         $task_group_id = $w->sessionOrRequest("task__task-group-id");


### PR DESCRIPTION
Simple change, when going to the task list, the filter will default to the logged in user _if they are looking at the list for the first time_. That is, if they change the filter assignee, then it should stay that way (the filter is session based).