### PR TITLE
Fix for timelog updates overriding previous owner

### DIFF
--- a/system/modules/timelog/models/Timelog.php
+++ b/system/modules/timelog/models/Timelog.php
@@ -144,7 +144,7 @@ class Timelog extends DbObject {
 		// If user is admin try and set the user_id to the given one from the timelog form
 		if ($this->w->Auth->user()->is_admin) {
 			$this->user_id = !empty($_POST['user_id']) ? intval($_POST['user_id']) : $this->w->Auth->user()->id;
-		} else {
+		} else if (empty($this->user_id)) {
 			$this->user_id = $this->w->Auth->user()->id;
 		}
 		
@@ -154,7 +154,7 @@ class Timelog extends DbObject {
 	public function update($force_null_values = false, $force_validation = true) {
 		if ($this->w->Auth->user()->is_admin) {
 			$this->user_id = !empty($_POST['user_id']) ? intval($_POST['user_id']) : $this->w->Auth->user()->id;
-		} else {
+		} else if (empty($this->user_id)) {
 			$this->user_id = $this->w->Auth->user()->id;
 		}
 		


### PR DESCRIPTION
Needs verification, fixes the issue with non-admin users overriding the ownership of someone else's timelog when they edit said timelog.

The scenario:

- User A creates timelog Z
- User B edits timelog Z (change the hours or something)
- Timelog Z now belongs to User B

This fix should stop that.