### PR TITLE
Moved timelog deletion from Task::delete into a hook on the Timelog module

### DIFF
--- a/system/modules/task/models/Task.php
+++ b/system/modules/task/models/Task.php
@@ -640,14 +640,6 @@ class Task extends DbObject {
                 $this->getTaskTypeObject()->on_before_delete($this);
             }
             
-            //delete all timelogs attached to the task
-            $timelogs = $this->getTimeLogEntries();
-            if (!empty($timelogs)) {
-                foreach ($timelogs as $log) {
-                    $log->delete();
-                }
-            }
-
             // 3. Delete the task
 
             parent::delete($force);

--- a/system/modules/timelog/timelog.hooks.php
+++ b/system/modules/timelog/timelog.hooks.php
@@ -5,3 +5,13 @@ function timelog_core_template_menu(Web $w) {
         return $w->partial('timelogwidget', null, 'timelog');
     }
 }
+
+// delete any timelogs attached to deleted object
+function timelog_core_dbobject_after_delete($w, $obj) {
+    $timelogs = $w->Timelog->getTimelogsForObject($obj);
+    if (!empty($timelogs)) {
+        foreach ($timelogs as $timelog) {
+            $timelog->delete();
+        }
+    }
+}


### PR DESCRIPTION
Moved timelog deletion from Task::delete into a hook on the Timelog module.
The Timelog module should listen to the deletion of ALL objects in Cmfive and work out if there are timelogs to remove.