### PR TITLE
Feature/is active on objects

### DIFF
--- a/system/modules/task/actions/edit.php
+++ b/system/modules/task/actions/edit.php
@@ -62,6 +62,9 @@ function edit_GET($w) {
     $form = array(
         (!empty($p["id"]) ? 'Edit task' : "Create a new task") => array(
             array(
+                array("Active", "checkbox", "is_active", $task->is_active)
+            ),
+            array(
                 (new Autocomplete())
                     ->setLabel("Task Group <small>Required</small>")
                     ->setName(!empty($p["id"]) ? "task_group_id_text" : "task_group_id")
@@ -180,6 +183,7 @@ function edit_GET($w) {
 }
 
 function edit_POST($w) {
+    
     $p = $w->pathMatch("id");
     $task = (!empty($p["id"]) ? $w->Task->getTask($p["id"]) : new Task($w));
     $taskdata = null;
@@ -187,7 +191,23 @@ function edit_POST($w) {
         $taskdata = $w->Task->getTaskData($p['id']);
     }
     
+    $is_active = !empty($p["id"]) ? $task->is_active : true;
+    $new_is_active = isset($_POST['edit']['is_active']) ? $_POST['edit']['is_active'] : false;
+
     $task->fill($_POST['edit']);
+// $w->out()
+    // if attempting to activate task check if taskgroup is active
+    if ($new_is_active != $is_active) {
+        //are we activating or deactivating
+        if ($_POST['edit']['is_active'] == false) {
+            $task->is_active = false;
+        } else {
+            //check if taskgroup is active
+            $taskgroup = $task->getTaskGroup();
+            $task->is_active = $taskgroup->is_active;
+        }
+    }
+    
 	if (empty($task->dt_assigned) || $task->assignee_id != intval($_POST['edit']['assignee_id'])) {
 		$task->dt_assigned = formatDateTime(time());
 	}

--- a/system/modules/task/actions/edit.php
+++ b/system/modules/task/actions/edit.php
@@ -62,9 +62,6 @@ function edit_GET($w) {
     $form = array(
         (!empty($p["id"]) ? 'Edit task' : "Create a new task") => array(
             array(
-                array("Active", "checkbox", "is_active", $task->is_active)
-            ),
-            array(
                 (new Autocomplete())
                     ->setLabel("Task Group <small>Required</small>")
                     ->setName(!empty($p["id"]) ? "task_group_id_text" : "task_group_id")
@@ -191,22 +188,7 @@ function edit_POST($w) {
         $taskdata = $w->Task->getTaskData($p['id']);
     }
     
-    $is_active = !empty($p["id"]) ? $task->is_active : true;
-    $new_is_active = isset($_POST['edit']['is_active']) ? $_POST['edit']['is_active'] : false;
-
     $task->fill($_POST['edit']);
-// $w->out()
-    // if attempting to activate task check if taskgroup is active
-    if ($new_is_active != $is_active) {
-        //are we activating or deactivating
-        if ($_POST['edit']['is_active'] == false) {
-            $task->is_active = false;
-        } else {
-            //check if taskgroup is active
-            $taskgroup = $task->getTaskGroup();
-            $task->is_active = $taskgroup->is_active;
-        }
-    }
     
 	if (empty($task->dt_assigned) || $task->assignee_id != intval($_POST['edit']['assignee_id'])) {
 		$task->dt_assigned = formatDateTime(time());

--- a/system/modules/task/actions/group/ajaxAutocompleteTaskgroups.php
+++ b/system/modules/task/actions/group/ajaxAutocompleteTaskgroups.php
@@ -4,7 +4,7 @@ function ajaxAutocompleteTaskgroups_GET(Web $w) {
 	$w->setLayout(null);
 	$term = $w->request("term");
 	
-	$taskgroups = $w->Task->getObjects("TaskGroup", ["title LIKE ?" => "%{$term}%"]);
+	$taskgroups = $w->Task->getObjects("TaskGroup", ["title LIKE ?" => "%{$term}%", "is_deleted" => 0, "is_active" => 1]);
 	$return_data = [];
 	if (!empty($taskgroups)) {
 		$taskgroups = array_filter($taskgroups, function($taskgroup) use ($w) {

--- a/system/modules/task/actions/group/viewtaskgroup.php
+++ b/system/modules/task/actions/group/viewtaskgroup.php
@@ -1,0 +1,109 @@
+<?php
+
+// display an editable form showing attributes of a task group
+function viewtaskgroup_GET(Web &$w) {
+	$p = $w->pathMatch("id");
+	// return task group details given a task group ID
+	$group_details = $w->Task->getTaskGroup($p['id']);
+
+	// if (!empty($group_details)) {
+	// 	History::add("Taskgroup: ".$group_details->title, null, $group_details);
+	// }
+	// if is_active is set to '0', display 'Yes', else display 'No'
+	$isactive = $group_details->is_active == "1" ? "Yes" : "No";
+
+	// set Is Task Active, Is Task Deleted dropdowns for display
+	$is_active = array(array("Yes","Yes"), array("No","No"));
+	$is_deleted = array(array("Yes","1"), array("No","0"));
+	
+	// get generic task group permissions
+	$arrassign = $w->Task->getTaskGroupPermissions();
+	// unset 'ALL' given all can never assign a task
+	unset($arrassign[0]);
+
+        // Get list of possible task types and priorities adn assignees
+        $tasktypes = $w->Task->getTaskTypes($group_details->task_group_type);
+        $priorities = $w->Task->getTaskPriority($group_details->task_group_type);
+        $assignees = $w->Task->getMembersInGroup($p['id']);
+        array_unshift($assignees,array("Unassigned","unassigned")); 
+        // No default assignee means it is unassigned
+        $default_assignee = (empty($group_details->default_assignee_id)) ? "unassigned" : $group_details->default_assignee_id;
+	
+	// build form displaying current attributes from database
+	$f = Html::form(array(
+			array("Task Group Details", "section"),
+			array("Task Group Type", "static", "task_group_type", $group_details->getTypeTitle()),
+			array("Title", "text", "title", $group_details->title),
+			array("Who Can Assign", "select", "can_assign", $group_details->can_assign, $arrassign),
+			array("Who Can View", "select", "can_view", $group_details->can_view, $w->Task->getTaskGroupPermissions()),
+			array("Who Can Create", "select", "can_create", $group_details->can_create, $w->Task->getTaskGroupPermissions()),
+			array("Is Active", "select", "is_active", $isactive, $is_active),
+			array("Description", "textarea", "description", $group_details->description, "26", "6"),
+			array("Default Task Type", "select", "default_task_type", $group_details->default_task_type, $tasktypes),
+			array("Default Priority", "select", "default_priority", $group_details->default_priority, $priorities),
+			array("Default Assignee", "select", "default_assignee_id", $default_assignee, $assignees),
+			array('Automatic Subscription', 'checkbox', 'is_automatic_subscription', $group_details->is_automatic_subscription)
+			), $w->localUrl("/task-group/viewtaskgroup/" . $group_details->id), "POST", "Update");
+
+	// display form
+	$w->setLayout(null);
+	$w->ctx("viewgroup",$f);
+}
+
+function viewtaskgroup_POST(Web &$w) {
+	$p = $w->pathMatch("id");
+	// get details of task group being edited
+	$group_details = $w->Task->getTaskGroup($p['id']);
+
+	// if group exists, update the details
+	if ($group_details) {
+        $group_details->fill($_REQUEST);
+        $group_details->is_active = $_POST['is_active'] == "Yes" ? 1 : 0;
+		$group_details->is_automatic_subscription = !empty($w->request('is_automatic_subscription'));
+		$response = $group_details->update();
+
+                // Check the validation
+                if ($response !== true) {
+                    $w->errorMessage($group_details, "Taskgroup", $response, true, "/task-group/viewmembergroup/".$p['id']."#members");
+                }                
+
+		// if a default assignee is set (other than unassigned), return their membership object for this group
+                $default_assignee_id = $_REQUEST['default_assignee_id'];
+		if (!empty($default_assignee_id) && $default_assignee_id != "unassigned") {
+			$mem = $w->Task->getMemberGroupById($group_details->id, $_REQUEST['default_assignee_id']);
+		
+			// populate an array with the required details for updating
+			// if the person is already a member we will maintain their current role
+			// otherwise we will make them the group owner. we also make them active in case they had been previously removed from the group
+			$arrdb = array();
+			$arrdb['task_group_id'] = $group_details->id;
+			$arrdb['user_id'] = $_REQUEST['default_assignee_id'];
+			$arrdb['role'] = $mem->role ? $mem->role : "OWNER";
+			$arrdb['priority'] = 1;
+			$arrdb['is_active'] = 1;
+			
+			// if they don't exist, create the membership entry, otherwise update their current entry
+			if (!$mem) {
+				$mem = new TaskGroupMember($w);
+				$mem->fill($arrdb);
+				$mem->insert();
+				}
+			else {
+				$mem->fill($arrdb);
+				$mem->update();
+				}
+			}
+		
+		// return with message
+		$w->msg("Task Group " . $group_details->title . " updated.","/task-group/viewmembergroup/".$group_details->id);
+	}
+	else {
+		// if group somehow no longer exists, say as much
+		$w->msg("Group: " . $_REQUEST['title'] . " no longer exists?","/task-group/viewtaskgroups/".$group_details->task_group_type);
+	}
+}
+
+
+
+
+

--- a/system/modules/task/actions/group/viewtaskgroup.php
+++ b/system/modules/task/actions/group/viewtaskgroup.php
@@ -37,7 +37,7 @@ function viewtaskgroup_GET(Web &$w) {
 			array("Who Can Assign", "select", "can_assign", $group_details->can_assign, $arrassign),
 			array("Who Can View", "select", "can_view", $group_details->can_view, $w->Task->getTaskGroupPermissions()),
 			array("Who Can Create", "select", "can_create", $group_details->can_create, $w->Task->getTaskGroupPermissions()),
-			array("Is Active", "select", "is_active", $isactive, $is_active),
+			//array("Is Active", "select", "is_active", $isactive, $is_active),
 			array("Description", "textarea", "description", $group_details->description, "26", "6"),
 			array("Default Task Type", "select", "default_task_type", $group_details->default_task_type, $tasktypes),
 			array("Default Priority", "select", "default_priority", $group_details->default_priority, $priorities),
@@ -58,7 +58,7 @@ function viewtaskgroup_POST(Web &$w) {
 	// if group exists, update the details
 	if ($group_details) {
         $group_details->fill($_REQUEST);
-        $group_details->is_active = $_POST['is_active'] == "Yes" ? 1 : 0;
+        //$group_details->is_active = $_POST['is_active'] == "Yes" ? 1 : 0;
 		$group_details->is_automatic_subscription = !empty($w->request('is_automatic_subscription'));
 		$response = $group_details->update();
 

--- a/system/modules/task/actions/group/viewtaskgrouptypes.php
+++ b/system/modules/task/actions/group/viewtaskgrouptypes.php
@@ -1,24 +1,34 @@
 <?php
 function viewtaskgrouptypes_ALL(Web $w) {
 	$w->Task->navigation($w, "Manage Task Groups");
-	
+	$show_inactive = $w->request('inactive') ? true : false;
+	$w->ctx('show_inactive',$show_inactive);
+
 	History::add("Manage Task Groups");
-	$task_groups = $w->Task->getTaskGroups();
+	$task_groups = $w->Task->getTaskGroups($show_inactive);
 	if ($task_groups) {
 		usort($task_groups, array("TaskService","sortbyGroup"));
 	}
 	// prepare column headings for display
-	$line = array(array("Title","Type", "Description", "Default Assignee"));
+	$headers = array("Title","Type", "Description", "Default Assignee");
+	if ($show_inactive) {
+		$headers[] = "Is Active";
+	}
+	$line = array($headers);
 
 	// if task group exists, display title, group type, description, default assignee and button for specific task group info
 	if ($task_groups) {
 		foreach ($task_groups as $group) {
-			$line[] = array(
+			$row = array(
 					Html::a(WEBROOT."/task-group/viewmembergroup/".$group->id,$group->title),
 					$group->getTypeTitle(),
 					$group->description,
 					$group->getDefaultAssigneeName(),
 			);
+			if ($show_inactive) {
+				$row[] = $group->is_active ? "Yes" : "No";
+			}
+			$line[] = $row;
 		}
 	}
 	else {

--- a/system/modules/task/actions/tasklist.php
+++ b/system/modules/task/actions/tasklist.php
@@ -11,7 +11,7 @@ function tasklist_ALL(Web $w) {
         // Get filter values
         $assignee_id = $w->sessionOrRequest("task__assignee-id", $w->Auth->user()->id);
         $creator_id = $w->sessionOrRequest("task__creator-id");
-
+        $show_inactive = $w->sessionOrRequest("task__show-inactive", 0);
         $task_group_id = $w->sessionOrRequest("task__task-group-id");
         $task_type = $w->sessionOrRequest('task__type');
         $task_priority = $w->sessionOrRequest('task__priority');
@@ -78,6 +78,11 @@ function tasklist_ALL(Web $w) {
             $query_object->where("task.dt_due <= ?", $dt_to);
         }
     }
+
+    if (empty($show_inactive) || !$show_inactive) {
+        $query_object->where("task.is_active", 1);
+    }
+    
     
     // Standard wheres
     $query_object->where("task.is_deleted", array(0, null)); //->where("task_group.is_active", 1)->where("task_group.is_deleted", 0);
@@ -134,7 +139,15 @@ function tasklist_ALL(Web $w) {
 			["label" => "No", "value" => '0'],
 			["label" => "Yes", "value" => '1'],
 			["label" => "Both", "value" => '']
-		])->setSelectedOption($is_closed) //array("Closed", "checkbox", "task__is-closed", !empty($is_closed) ? $is_closed : null)
+        ])->setSelectedOption($is_closed), //array("Closed", "checkbox", "task__is-closed", !empty($is_closed) ? $is_closed : null)
+        (new \Html\Form\Select([
+            "label"     => "Show Inacitve",
+            "name"      => "task__show-inactive",
+            "id"        => "task__show-inactive"
+        ]))->setOptions([
+            ["label" => "No", "value" => '0'],
+            ["label" => "Yes", "value" => '1']
+        ])->setSelectedOption(isset($show_inactive) ? $show_inactive : '0')
     );
     
     $w->ctx("filter_data", $filter_data);

--- a/system/modules/task/install/migrations/20180823160320-TaskAddIsActiveToTask.php
+++ b/system/modules/task/install/migrations/20180823160320-TaskAddIsActiveToTask.php
@@ -1,0 +1,15 @@
+<?php
+
+class TaskAddIsActiveToTask extends CmfiveMigration {
+
+	public function up() {
+		// UP
+		$this->addColumnToTable('task', 'is_active', 'boolean', ['default' => true]);
+	}
+
+	public function down() {
+		// DOWN
+		$this->removeColumnFromTable('task', 'is_active');
+	}
+
+}

--- a/system/modules/task/models/Task.php
+++ b/system/modules/task/models/Task.php
@@ -27,6 +27,7 @@ class Task extends DbObject {
     public $_modifiable;  // Modifiable Aspect
     public $_searchable;
     public $rate; //rate used for calculating invoice values
+    public $is_active;
     public static $_validation = array(
         "title" => array('required'),
         "task_group_id" => array('required'),

--- a/system/modules/task/models/TaskService.php
+++ b/system/modules/task/models/TaskService.php
@@ -229,8 +229,12 @@ class TaskService extends DbService {
     }
 
     // get all active task groups from the database
-    function getTaskGroups() {
-        return $this->getObjects("TaskGroup", array("is_active" => 1, "is_deleted" => 0));
+    function getTaskGroups($include_inactive = false) {
+        $where = ["is_deleted" => 0];
+        if (!$include_inactive) {
+            $where['is_active'] = 1;
+        }
+        return $this->getObjects("TaskGroup", $where);
     }
 
     // get all task groups from the database of given task group type

--- a/system/modules/task/partials/actions/listtasks.php
+++ b/system/modules/task/partials/actions/listtasks.php
@@ -40,6 +40,7 @@ function listtasks(\Web $w, $params = array()) {
         $is_closed = $w->request("is_closed");
         $dt_from = $w->request('dt_from');
         $dt_to = $w->request('dt_to');
+        $include_inactive = $w->request('include_inactive');
     }
     // Make the query manually
     $query_object = $w->db->get("task")->leftJoin("task_group");
@@ -69,6 +70,9 @@ function listtasks(\Web $w, $params = array()) {
         $query_object->where("task.is_closed", ((is_null($is_closed) || $is_closed == 0) ? 0 : 1));
     } else {
         $query_object->where("task.is_closed", 0);
+    }
+    if (empty($include_inactive)) {
+        $query_object->where("task.is_active", 1);
     }
     // This part is why we want to make our query manually
     if (!empty($dt_from)) {

--- a/system/modules/task/task.group.actions.php
+++ b/system/modules/task/task.group.actions.php
@@ -5,55 +5,7 @@
 ////////////////////////////////////////////
 
 
-// display an editable form showing attributes of a task group
-function viewtaskgroup_GET(Web &$w) {
-	$p = $w->pathMatch("id");
-	// return task group details given a task group ID
-	$group_details = $w->Task->getTaskGroup($p['id']);
 
-	if (!empty($group_details)) {
-		History::add("Taskgroup: ".$group_details->title, null, $group_details);
-	}
-	// if is_active is set to '0', display 'Yes', else display 'No'
-	$isactive = $group_details->is_active == "1" ? "Yes" : "No";
-
-	// set Is Task Active, Is Task Deleted dropdowns for display
-	$is_active = array(array("Yes","1"), array("No","0"));
-	$is_deleted = array(array("Yes","1"), array("No","0"));
-	
-	// get generic task group permissions
-	$arrassign = $w->Task->getTaskGroupPermissions();
-	// unset 'ALL' given all can never assign a task
-	unset($arrassign[0]);
-
-        // Get list of possible task types and priorities adn assignees
-        $tasktypes = $w->Task->getTaskTypes($group_details->task_group_type);
-        $priorities = $w->Task->getTaskPriority($group_details->task_group_type);
-        $assignees = $w->Task->getMembersInGroup($p['id']);
-        array_unshift($assignees,array("Unassigned","unassigned")); 
-        // No default assignee means it is unassigned
-        $default_assignee = (empty($group_details->default_assignee_id)) ? "unassigned" : $group_details->default_assignee_id;
-	
-	// build form displaying current attributes from database
-	$f = Html::form(array(
-			array("Task Group Details", "section"),
-			array("Task Group Type", "static", "task_group_type", $group_details->getTypeTitle()),
-			array("Title", "text", "title", $group_details->title),
-			array("Who Can Assign", "select", "can_assign", $group_details->can_assign, $arrassign),
-			array("Who Can View", "select", "can_view", $group_details->can_view, $w->Task->getTaskGroupPermissions()),
-			array("Who Can Create", "select", "can_create", $group_details->can_create, $w->Task->getTaskGroupPermissions()),
-			array("Is Active", "select", "is_active", $group_details->is_active, $is_active),
-			array("Description", "textarea", "description", $group_details->description, "26", "6"),
-			array("Default Task Type", "select", "default_task_type", $group_details->default_task_type, $tasktypes),
-			array("Default Priority", "select", "default_priority", $group_details->default_priority, $priorities),
-			array("Default Assignee", "select", "default_assignee_id", $default_assignee, $assignees),
-			array('Automatic Subscription', 'checkbox', 'is_automatic_subscription', $group_details->is_automatic_subscription)
-			), $w->localUrl("/task-group/updatetaskgroup/" . $group_details->id), "POST", "Update");
-
-	// display form
-	$w->setLayout(null);
-	$w->ctx("viewgroup",$f);
-}
 
 function createtaskgroup_POST(Web &$w) {
     $taskgroup = $w->Task->createTaskGroup(
@@ -75,57 +27,7 @@ function createtaskgroup_POST(Web &$w) {
     $w->msg("<div id='saved_record_id' data-id='".$taskgroup->id."' >Task Group ".$taskgroup->title." added</div>", "/task-group/viewmembergroup/".$taskgroup->id."#members");
 }
 
-function updatetaskgroup_POST(Web &$w) {
-	$p = $w->pathMatch("id");
-	// get details of task group being edited
-	$group_details = $w->Task->getTaskGroup($p['id']);
 
-	// if group exists, update the details
-	if ($group_details) {
-		$group_details->fill($_REQUEST);
-		$group_details->is_automatic_subscription = !empty($w->request('is_automatic_subscription'));
-		$response = $group_details->update();
-
-                // Check the validation
-                if ($response !== true) {
-                    $w->errorMessage($group_details, "Taskgroup", $response, true, "/task-group/viewmembergroup/".$p['id']."#members");
-                }                
-
-		// if a default assignee is set (other than unassigned), return their membership object for this group
-                $default_assignee_id = $_REQUEST['default_assignee_id'];
-		if (!empty($default_assignee_id) && $default_assignee_id != "unassigned") {
-			$mem = $w->Task->getMemberGroupById($group_details->id, $_REQUEST['default_assignee_id']);
-		
-			// populate an array with the required details for updating
-			// if the person is already a member we will maintain their current role
-			// otherwise we will make them the group owner. we also make them active in case they had been previously removed from the group
-			$arrdb = array();
-			$arrdb['task_group_id'] = $group_details->id;
-			$arrdb['user_id'] = $_REQUEST['default_assignee_id'];
-			$arrdb['role'] = $mem->role ? $mem->role : "OWNER";
-			$arrdb['priority'] = 1;
-			$arrdb['is_active'] = 1;
-			
-			// if they don't exist, create the membership entry, otherwise update their current entry
-			if (!$mem) {
-				$mem = new TaskGroupMember($w);
-				$mem->fill($arrdb);
-				$mem->insert();
-				}
-			else {
-				$mem->fill($arrdb);
-				$mem->update();
-				}
-			}
-		
-		// return with message
-		$w->msg("Task Group " . $group_details->title . " updated.","/task-group/viewmembergroup/".$group_details->id);
-	}
-	else {
-		// if group somehow no longer exists, say as much
-		$w->msg("Group: " . $_REQUEST['title'] . " no longer exists?","/task-group/viewtaskgroups/".$group_details->task_group_type);
-	}
-}
 
 function deletetaskgroup_GET(Web &$w) {
 	$w->setLayout(null);

--- a/system/modules/task/task.hooks.php
+++ b/system/modules/task/task.hooks.php
@@ -308,12 +308,12 @@ function task_comment_send_notification_recipients_task(Web $w, $params) {
 // if taskgroup has been made inactive, then deactivate all attached tasks
 function task_core_dbobject_after_update_TaskGroup(Web $w, $object) {
 	// check if is_active flag has changed from 1 to 0
-	if ($object->__old && $object->__old["is_active"] !== $object->is_active && !$object->is_active) {
+	if ($object->__old && $object->__old["is_active"] !== $object->is_active) {
 		// get all attached tasks
 		$tasks = $object->getTasks();
 		if (!empty($tasks)) {
 			foreach ($tasks as $task) {
-				$task->is_active = 0;
+				$task->is_active = $object->is_active;
 				$task->update();
 			}
 		}

--- a/system/modules/task/task.hooks.php
+++ b/system/modules/task/task.hooks.php
@@ -304,3 +304,18 @@ function task_comment_send_notification_recipients_task(Web $w, $params) {
     });
 
 }
+
+// if taskgroup has been made inactive, then deactivate all attached tasks
+function task_core_dbobject_after_update_TaskGroup(Web $w, $object) {
+	// check if is_active flag has changed from 1 to 0
+	if ($object->__old && $object->__old["is_active"] !== $object->is_active && !$object->is_active) {
+		// get all attached tasks
+		$tasks = $object->getTasks();
+		if (!empty($tasks)) {
+			foreach ($tasks as $task) {
+				$task->is_active = 0;
+				$task->update();
+			}
+		}
+	}
+}

--- a/system/modules/task/templates/group/viewtaskgrouptypes.tpl.php
+++ b/system/modules/task/templates/group/viewtaskgrouptypes.tpl.php
@@ -5,6 +5,7 @@
     </div>
     <div class="tab-body">
         <div id="dashboard">
+            <?php echo !$show_inactive ? Html::b('/task-group/viewtaskgrouptypes?inactive=true','Show Inactive taskgroups') : Html::b('/task-group/viewtaskgrouptypes','Hide Inactive taskgroups'); ?>
             <?php echo $dashboard; ?>
         </div>
         <div id="create" class="clearfix">


### PR DESCRIPTION
utilises 'is_active' on taskgroups and tasks

'is_active' is hidden from all edit forms.
When a taskgroup is made inactive all linked tasks are made inactive. Conversely when taskgroups are made active all tasks are made active.
