### PR TITLE
fix: Admin config log issue

### DIFF
--- a/system/modules/admin/config.php
+++ b/system/modules/admin/config.php
@@ -48,7 +48,8 @@ Config::set('admin', [
             'region'    => 'ap-southeast-2',
             'version'   => 'latest',
         ],
-        "level" => \Monolog\Logger::DEBUG,
+        // This value comes from \Monolog\Logger::DEBUG constant.
+        "level" => 100,
     ],
     "mail" => [
         "aws" => [


### PR DESCRIPTION
Updated admin.logging.level to be a copy of the value of the \Monolog\Logger::DEBUG constant as this might not always be loaded due to the order at which the different configs are loaded.
