### PR TITLE
fix: Timelog issue

### DIFF
--- a/system/modules/task/models/Task.php
+++ b/system/modules/task/models/Task.php
@@ -29,12 +29,12 @@ class Task extends DbObject
     public $_searchable;
     public $rate; //rate used for calculating invoice values
     public $is_active;
-    public static $_validation = array(
-        "title" => array('required'),
-        "task_group_id" => array('required'),
-        "status" => array('required'),
-        "task_type" => array('required'),
-    );
+    public static $_validation = [
+        "title" => ['required'],
+        "task_group_id" => ['required'],
+        "status" => ['required'],
+        "task_type" => ['required'],
+    ];
     public static $_db_table = "task";
 
     /**
@@ -76,26 +76,26 @@ class Task extends DbObject
     public function addTaskGroupAsSubscribers()
     {
         $taskgroup = $this->getTaskGroup();
-            if (!empty($taskgroup->id)) {
-                // If automatic subscribe is ticked, assign all members as subscribers
-                if ($taskgroup->shouldAutomaticallySubscribe()) {
-                    $members = $taskgroup->getMembers();
-                    if (!empty($members)) {
-                        foreach ($members as $member) {
-                            $member_user = $this->w->Auth->getUser($member->user_id);
+        if (!empty($taskgroup->id)) {
+            // If automatic subscribe is ticked, assign all members as subscribers
+            if ($taskgroup->shouldAutomaticallySubscribe()) {
+                $members = $taskgroup->getMembers();
+                if (!empty($members)) {
+                    foreach ($members as $member) {
+                        $member_user = AuthService::getInstance($this->w)->getUser($member->user_id);
 
-                            if (!empty($member_user->id)) {
-                                $this->addSubscriber($member_user);
-                            }
+                        if (!empty($member_user->id)) {
+                            $this->addSubscriber($member_user);
                         }
                     }
-                    // Else only assign the assignee and creator
-                } else {
-                    $creator_id = $this->getTaskCreatorId();
-                    $this->addSubscriber($this->w->Auth->getUser($creator_id));
-                    $this->addSubscriber($this->w->Auth->getUser($this->assignee_id));
                 }
+                // Else only assign the assignee and creator
+            } else {
+                $creator_id = $this->getTaskCreatorId();
+                $this->addSubscriber(AuthService::getInstance($this->w)->getUser($creator_id));
+                $this->addSubscriber(AuthService::getInstance($this->w)->getUser($this->assignee_id));
             }
+        }
     }
 
     /**
@@ -133,7 +133,7 @@ class Task extends DbObject
 
     public function isUrgent()
     {
-        $taskgroup_type_object = $this->w->Task->getTaskGroupTypeObject($this->_taskgroup->task_group_type);
+        $taskgroup_type_object = TaskService::getInstance($this->w)->getTaskGroupTypeObject($this->_taskgroup->task_group_type);
         if (!empty($taskgroup_type_object->id)) {
             return $taskgroup_type_object->isUrgentPriority($this->priority);
         } else {
@@ -171,7 +171,7 @@ class Task extends DbObject
     public function getDataValue($key)
     {
         if ($this->id) {
-            $c = $this->Task->getObject("TaskData", array("task_id" => $this->id, "data_key" => $key));
+            $c = $this->Task->getObject("TaskData", ["task_id" => $this->id, "data_key" => $key]);
             if ($c) {
                 return $c->value;
             }
@@ -188,7 +188,7 @@ class Task extends DbObject
     public function setDataValue($key, $value)
     {
         if ($this->id) {
-            $c = $this->Task->getObject("TaskData", array("task_id" => $this->id, "data_key" => $key));
+            $c = $this->Task->getObject("TaskData", ["task_id" => $this->id, "data_key" => $key]);
             if ($c) {
                 $c->value = $value;
                 $c->update();
@@ -206,7 +206,7 @@ class Task extends DbObject
     public function getCanIView(User $user = null)
     {
         if (empty($user)) {
-            $user = $this->w->Auth->user();
+            $user = AuthService::getInstance($this->w)->user();
         }
 
         if (empty($user->id)) {
@@ -245,7 +245,7 @@ class Task extends DbObject
      */
     public function canISetRate()
     {
-        $user = $this->w->auth->User();
+        $user = AuthService::getInstance($this->w)->User();
         $taskgroup = $this->getTaskGroup();
         if (!empty($taskgroup) && !empty($user)) {
             if ($user->is_admin == 1 || $taskgroup->isOwner($user)) {
@@ -336,10 +336,10 @@ class Task extends DbObject
             return true;
         }
 
-        $logged_in_user_id = $this->w->Auth->user()->id;
+        $logged_in_user_id = AuthService::getInstance($this->w)->user()->id;
         $me = $this->Task->getMemberGroupById($this->task_group_id, $logged_in_user_id);
 
-        if (($logged_in_user_id == $this->assignee_id) || ($logged_in_user_id == $this->getTaskCreatorId()) || (!empty($me->role) && $this->w->Task->getMyPerms($me->role, "OWNER"))) {
+        if (($logged_in_user_id == $this->assignee_id) || ($logged_in_user_id == $this->getTaskCreatorId()) || (!empty($me->role) && TaskService::getInstance($this->w)->getMyPerms($me->role, "OWNER"))) {
             return true;
         }
         return false;
@@ -348,7 +348,7 @@ class Task extends DbObject
     // return the ID of the task creator given a task ID
     public function getTaskCreatorId()
     {
-        $c = $this->Task->getObject("ObjectModification", array("object_id" => $this->id, "table_name" => $this->getDbTableName()));
+        $c = $this->Task->getObject("ObjectModification", ["object_id" => $this->id, "table_name" => $this->getDbTableName()]);
         return $c ? $c->creator_id : "";
     }
 
@@ -358,7 +358,7 @@ class Task extends DbObject
         // I've moved the creator_id to tasks but this is for backwards compatability
         $creator = null;
         if (empty($this->creator_id)) {
-            $c = $this->Task->getObject("ObjectModification", array("object_id" => $this->id, "table_name" => $this->getDbTableName()));
+            $c = $this->Task->getObject("ObjectModification", ["object_id" => $this->id, "table_name" => $this->getDbTableName()]);
             if (!empty($c->creator_id)) {
                 $creator = $this->Auth->getUser($c->creator_id);
             }
@@ -411,7 +411,7 @@ class Task extends DbObject
         }
 
         if (!empty($this->_taskgroup->id)) {
-            $statlist = $this->_taskgroup->getStatus(); //Task->getTaskStatus($this->w->Task->getTaskGroupTypeById($this->task_group_id));
+            $statlist = $this->_taskgroup->getStatus();
             if ($statlist) {
                 foreach ($statlist as $stat) {
                     $status[$stat[0]] = $stat[1];
@@ -424,7 +424,7 @@ class Task extends DbObject
     // return the task priorities as array given a task group ID
     public function getTaskGroupPriority()
     {
-        return (!empty($this->_taskgroup->id) ? $this->_taskgroup->getPriority() : null); //Task->getTaskPriority($this->w->Task->getTaskGroupTypeById($this->task_group_id));
+        return (!empty($this->_taskgroup->id) ? $this->_taskgroup->getPriority() : null);
     }
 
     // return list of time log entries for a task given task ID
@@ -433,8 +433,7 @@ class Task extends DbObject
         if (empty($id)) {
             $id = $this->id;
         }
-        return $this->getObjects("timelog", array("object_class" => "Task", "object_id" => $id, "is_deleted" => 0));
-
+        return $this->getObjects("timelog", ["object_class" => "Task", "object_id" => $id, "is_deleted" => 0]);
     }
 
     // return list of task time log entries, sort by start date
@@ -443,7 +442,7 @@ class Task extends DbObject
         $timelog = $this->getTimeLogEntries($this->id);
 
         if ($timelog) {
-            usort($timelog, array("TaskService", "sortByStarted"));
+            usort($timelog, ["TaskService", "sortByStarted"]);
         }
 
         return $timelog;
@@ -505,7 +504,7 @@ class Task extends DbObject
     public function toLink($class = null, $target = null, $user = null)
     {
         if (empty($user)) {
-            $user = $this->w->Auth->user();
+            $user = AuthService::getInstance($this->w)->user();
         }
         if ($this->canView($user)) {
             return Html::a($this->w->localUrl($this->printSearchUrl()), (!empty($this->title) ? htmlentities($this->title) : 'Task [' . $this->id . ']'), null, $class, null, $target);
@@ -547,7 +546,6 @@ class Task extends DbObject
 
             $tg = $this->getTaskGroup();
             if (!empty($tg)) {
-
                 if ($this->isStatusClosed()) {
                     $this->is_closed = 1;
                     // check dt_completed and set if empty
@@ -570,7 +568,7 @@ class Task extends DbObject
 
             //check if assigned
             if (!empty($this->assignee_id)) {
-                $user = $this->w->Auth->getUser($this->assignee_id);
+                $user = AuthService::getInstance($this->w)->getUser($this->assignee_id);
                 if (!empty($user->id)) {
                     // is assigned, check dt fields
                     if (empty($this->dt_assigned)) {
@@ -658,7 +656,7 @@ class Task extends DbObject
 
         //check if assigned and update dt fields
         if (!empty($this->assignee_id)) {
-            $user = $this->w->Auth->getUser($this->assignee_id);
+            $user = AuthService::getInstance($this->w)->getUser($this->assignee_id);
             if (!empty($user->id)) {
                 // is assigned, check dt fields
                 if (empty($this->dt_assigned) || $this->assignee_id != $this->__old['assignee_id']) {
@@ -717,7 +715,7 @@ class Task extends DbObject
 
             //if not 'unassigned' add user to subscribers
             //check user exists
-            $user = $this->w->auth->getUser($this->assignee_id);
+            $user = AuthService::getInstance($this->w)->getUser($this->assignee_id);
             $this->addSubscriber($user);
 
             $this->commitTransaction();
@@ -833,7 +831,7 @@ END:VCALENDAR";
 
     public function getAttachmentsFileList($include_channel_email_raw = false)
     {
-        $attachments = $this->w->File->getAttachments($this);
+        $attachments = FileService::getInstance($this->w)->getAttachments($this);
         if (!empty($attachments)) {
             if (!$include_channel_email_raw) {
                 $attachments = array_filter($attachments, function ($attachment) {
@@ -843,7 +841,7 @@ END:VCALENDAR";
                     return true;
                 });
             }
-            $pluck = array();
+            $pluck = [];
             foreach ($attachments as $attachment) {
                 $file_path = $attachment->getFilePath();
                 if ($file_path[strlen($file_path) - 1] !== '/') {
@@ -853,7 +851,6 @@ END:VCALENDAR";
             }
             return $pluck;
         }
-        return array();
+        return [];
     }
-
 }

--- a/system/modules/task/task.hooks.php
+++ b/system/modules/task/task.hooks.php
@@ -39,10 +39,9 @@ function task_timelog_type_options_for_Task(Web $w, $object)
     return [(new \Html\Form\Select([
         "name" => "time_type",
         "id" => "time_type",
-        "options" => $time_types,
         "label" => "Task time",
         "required" => $required,
-    ]))->setSelectedOption($object->time_type)];
+    ]))->setOptions($time_types, true)->setSelectedOption($object->time_type)];
 }
 
 /**
@@ -280,7 +279,7 @@ function task_comment_send_notification_recipients_task(Web $w, $params)
 
         $template_data['can_view_task'] = $user->is_external ? false : true;
 
-        $template_data['footer'] .= $w->partial("displaycomment", array("object" => $params['comment'], "displayOnly" => true, 'redirect' => '/inbox', "is_outgoing" => true), "admin");
+        $template_data['footer'] .= $w->partial("displaycomment", ["object" => $params['comment'], "displayOnly" => true, 'redirect' => '/inbox', "is_outgoing" => true], "admin");
 
         // Get additional details
         if ($user->is_external == 0) {

--- a/system/modules/timelog/actions/edit.php
+++ b/system/modules/timelog/actions/edit.php
@@ -1,123 +1,129 @@
 <?php
 
-function edit_GET(Web $w) {
+function edit_GET(Web $w)
+{
+    $p = $w->pathMatch("id");
 
-	$p = $w->pathMatch("id");
+    if (!empty($p['id'])) {
+        $timelog = TimelogService::getInstance($w)->getTimelog($p['id']);
+        if (empty($timelog)) {
+            $w->msg("Timelog not found", "/timelog");
+        }
+        if (!$timelog->canEdit(AuthService::getInstance($w)->user())) {
+            $w->msg("You cannot edit this Timelog", "/timelog");
+        }
+    } else {
+        $timelog = new Timelog($w);
+    }
 
-	if (!empty($p['id'])) {
-		$timelog = $w->Timelog->getTimelog($p['id']);
-		if (empty($timelog)) {
-			$w->msg("Timelog not found", "/timelog");
-		}
-		if (!$timelog->canEdit($w->Auth->user())) {
-			$w->msg("You cannot edit this Timelog", "/timelog");
-		}
-	} else {
-		$timelog = new Timelog($w);
-	}
+    $w->ctx("timelog", $timelog);
+    $w->ctx('redirect', $w->request("redirect", ''));
 
+    $indexes = TimelogService::getInstance($w)->getLoggableObjects();
+    $select_indexes = [];
+    if (!empty($indexes)) {
+        foreach ($indexes as $friendly_name => $search_name) {
+            $select_indexes[] = [$friendly_name, $search_name];
+        }
+    }
+    $w->ctx("select_indexes", $select_indexes);
 
+    $tracking_id = $w->request("id");
+    $tracking_class = $w->request("class");
+    $w->ctx("tracking_id", $tracking_id);
+    $w->ctx("tracking_class", $tracking_class);
 
-	$w->ctx("timelog", $timelog);
-	$w->ctx('redirect', $w->request("redirect", ''));
+    // If timelog.object_id is required then we must require the search field
+    $validation = Timelog::$_validation;
+    if (!empty($validation["object_id"])) {
+        if (in_array("required", $validation["object_id"])) {
+            $validation["search"] = ['required'];
+        }
+    }
 
-        $indexes = $w->timelog->getLoggableObjects();
-        $select_indexes = [];
-        if (!empty($indexes)) {
-            foreach($indexes as $friendly_name => $search_name) {
+    $object = TimelogService::getInstance($w)->getObject($timelog->object_class ?: $tracking_class, $timelog->object_id ?: $tracking_id);
+    $w->ctx("object", $object);
+    // Hook relies on knowing the timelogs time_type record, but also the object, so we give the time_type to object
+    if (!empty($object->id) && !empty($timelog->id)) {
+        $object->time_type = $timelog->time_type;
+    }
 
-                $select_indexes[] = array($friendly_name, $search_name);
+    $form = [];
+    if (!empty($object)) {
+        $additional_form_fields = $w->callHook("timelog", "type_options_for_" . get_class($object), $object);
+        if (!empty($additional_form_fields[0])) {
+            $form['Additional Fields'] = [];
+            foreach ($additional_form_fields as $form_fields) {
+                $form['Additional Fields'][] = $form_fields;
             }
         }
-	$w->ctx("select_indexes", $select_indexes);
+    }
+    $w->ctx("form", $form);
 
-	$tracking_id = $w->request("id");
-	$tracking_class = $w->request("class");
-	$w->ctx("tracking_id", $tracking_id);
-	$w->ctx("tracking_class", $tracking_class);
-
-	// If timelog.object_id is required then we must require the search field
-	$validation = Timelog::$_validation;
-	if (!empty($validation["object_id"])) {
-		if (in_array("required", $validation["object_id"])) {
-			$validation["search"] = array('required');
-		}
-	}
-
-	$object = $w->Timelog->getObject($timelog->object_class ? : $tracking_class, $timelog->object_id ? : $tracking_id);
-	$w->ctx("object", $object);
-	// Hook relies on knowing the timelogs time_type record, but also the object, so we give the time_type to object
-	if (!empty($object->id) && !empty($timelog->id)) {
-		$object->time_type = $timelog->time_type;
-	}
-
-	$form = [];
-	if (!empty($object)) {
-		$additional_form_fields = $w->callHook("timelog", "type_options_for_" . get_class($object), $object);
-		if (!empty($additional_form_fields[0])) {
-			$form['Additional Fields'] = array();
-			foreach($additional_form_fields as $form_fields) {
-				$form['Additional Fields'][] = $form_fields;
-			}
-		}
-	}
-	$w->ctx("form", $form);
+    if (AuthService::getInstance($w)->user()->is_admin) {
+        $users = AuthService::getInstance($w)->getUsers();
+        usort($users, function ($a, $b) {
+            return strcmp($a->getContact()->getFullName(), $b->getContact()->getFullName());
+        });
+        $w->ctx("options", $users);
+    }
 }
 
-function edit_POST(Web $w) {
-	$p = $w->pathMatch("id");
-	$redirect = $w->request("redirect", '');
+function edit_POST(Web $w)
+{
+    $p = $w->pathMatch("id");
+    $redirect = $w->request("redirect", '');
 
-	$timelog = !empty($p['id']) ? $w->Timelog->getTimelog($p['id']) : new Timelog($w);
+    $timelog = !empty($p['id']) ? TimelogService::getInstance($w)->getTimelog($p['id']) : new Timelog($w);
 
-	// Get and save timelog
-	if (empty($_POST['object_class']) || empty($_POST['object_id'])) {
-		$w->error('Missing module or search data', $redirect ? : '/timelog');
-	}
+    // Get and save timelog
+    if (empty($_POST['object_class']) || empty($_POST['object_id'])) {
+        $w->error('Missing module or search data', $redirect ?: '/timelog');
+    }
 
-	if (!array_key_exists("date_start", $_POST) || !array_key_exists("time_start", $_POST) || (!$timelog->isRunning() && (!array_key_exists("time_end", $_POST) && !array_key_exists("hours_worked", $_POST)))) {
-		$w->error('Missing date/time data', $redirect ? : '/timelog');
-	}
+    if (!array_key_exists("date_start", $_POST) || !array_key_exists("time_start", $_POST) || (!$timelog->isRunning() && (!array_key_exists("time_end", $_POST) && !array_key_exists("hours_worked", $_POST)))) {
+        $w->error('Missing date/time data', $redirect ?: '/timelog');
+    }
 
-	// Get start and end date/time
-	$time_object = null;
-	try {
-		$time_object = new DateTime(str_replace('/', '-', $_POST['date_start']) . ' ' . $_POST['time_start']);
-	} catch (Exception $e) {
-		$w->Log->setLogger("TIMELOG")->error($e->getMessage() . " in " . $e->getFile() . " on line " . $e->getLine());
-		$w->error('Invalid start date or time', $redirect ? : '/timelog');
-	}
+    // Get start and end date/time
+    $time_object = null;
+    try {
+        $time_object = new DateTime(str_replace('/', '-', $_POST['date_start']) . ' ' . $_POST['time_start']);
+    } catch (Exception $e) {
+        LogService::getInstance($w)->setLogger("TIMELOG")->error($e->getMessage() . " in " . $e->getFile() . " on line " . $e->getLine());
+        $w->error('Invalid start date or time', $redirect ?: '/timelog');
+    }
 
-	$timelog->object_class = $_POST['object_class'];
-	$timelog->object_id = $_POST['object_id'];
-	$timelog->time_type = !empty($_POST['time_type']) ? $_POST['time_type'] : null;
+    $timelog->object_class = $_POST['object_class'];
+    $timelog->object_id = $_POST['object_id'];
+    $timelog->time_type = !empty($_POST['time_type']) ? $_POST['time_type'] : null;
 
-	$timelog->dt_start = $time_object->format('Y-m-d H:i:s');
+    $timelog->dt_start = $time_object->format('Y-m-d H:i:s');
 
-	if ($_POST['select_end_method'] === "time") {
-		try {
-			$end_time_object = new DateTime(str_replace('/', '-', $_POST['date_start']) . ' ' . $_POST['time_end']);
-			$timelog->dt_end = $end_time_object->format('Y-m-d H:i:s');
-		} catch (Exception $e) {
-			$w->Log->setLogger("TIMELOG")->error($e->getMessage() . " in " . $e->getFile() . " on line " . $e->getLine());
-			$w->error('Invalid start date or time', $redirect ? : '/timelog');
-		}
-	} else {
-		if (!empty($_POST['hours_worked']) || !empty($_POST['minutes_worked'])) {
-			$time_object->add(new DateInterval("PT" . intval($_POST['hours_worked']) . "H" . (!empty($_POST['minutes_worked']) ? intval($_POST['minutes_worked']) : 0) . "M0S"));
-			$timelog->dt_end = $time_object->format('Y-m-d H:i:s');
-		}
-	}
-	
-	if (empty($timelog->user_id)) {
-		$timelog->user_id = !empty($_POST['user_id']) ? intval($_POST['user_id']) : $this->w->Auth->user()->id;
-	}
-	
-	// Timelog user_id handled in insert/update
-	$timelog->insertOrUpdate();
+    if ($_POST['select_end_method'] === "time") {
+        try {
+            $end_time_object = new DateTime(str_replace('/', '-', $_POST['date_start']) . ' ' . $_POST['time_end']);
+            $timelog->dt_end = $end_time_object->format('Y-m-d H:i:s');
+        } catch (Exception $e) {
+            LogService::getInstance($w)->setLogger("TIMELOG")->error($e->getMessage() . " in " . $e->getFile() . " on line " . $e->getLine());
+            $w->error('Invalid start date or time', $redirect ?: '/timelog');
+        }
+    } else {
+        if (!empty($_POST['hours_worked']) || !empty($_POST['minutes_worked'])) {
+            $time_object->add(new DateInterval("PT" . intval($_POST['hours_worked']) . "H" . (!empty($_POST['minutes_worked']) ? intval($_POST['minutes_worked']) : 0) . "M0S"));
+            $timelog->dt_end = $time_object->format('Y-m-d H:i:s');
+        }
+    }
 
-	// Save comment
-	$timelog->setComment($_POST['description']);
+    if (empty($timelog->user_id)) {
+        $timelog->user_id = !empty($_POST['user_id']) ? intval($_POST['user_id']) : AuthService::getInstance($w)->user()->id;
+    }
 
-	$w->msg("<div id='saved_record_id' data-id='".$timelog->id."' >Timelog saved</div>", (!empty($redirect) ? $redirect . "#timelog" : "/timelog"));
+    // Timelog user_id handled in insert/update
+    $timelog->insertOrUpdate();
+
+    // Save comment
+    $timelog->setComment($_POST['description']);
+
+    $w->msg("<div id='saved_record_id' data-id='" . $timelog->id . "' >Timelog saved</div>", (!empty($redirect) ? $redirect . "#timelog" : "/timelog"));
 }

--- a/system/modules/timelog/templates/edit.tpl.php
+++ b/system/modules/timelog/templates/edit.tpl.php
@@ -10,16 +10,14 @@
                 <li>
                     <label class="small-12 columns">Assigned User
                         <small>Required</small>
-                        <?php if ($w->Auth->user()->is_admin) {
-                            echo (new \Html\Form\Autocomplete([
+                        <?php if (AuthService::getInstance($w)->user()->is_admin && !empty($options)) {
+                            echo (new \Html\Form\Select([
                                 "id|name"    => "user_id",
-                                "title"        => empty($timelog->id) ? $w->Auth->user()->getFullName() : (!empty($timelog->user_id) ? $w->Auth->getUser($timelog->user_id)->getFullName() : null),
-                                "value"        => empty($timelog->id) ? $w->Auth->user()->id : (!empty($timelog->user_id) ? $timelog->user_id : null)
-                            ]))->setOptions($w->Auth->getUsers());
+                            ]))->setOptions($options, true)->setSelectedOption(empty($timelog->id) ? AuthService::getInstance($w)->user()->id : (!empty($timelog->user_id) ? $timelog->user_id : null));
                         } else {
                             echo (new \Html\Form\InputField\Hidden([
                                 "name"        => "user_id",
-                                "value"        => empty($timelog->id) ? $w->Auth->user()->id : $timelog->user_id
+                                "value"        => empty($timelog->id) ? AuthService::getInstance($w)->user()->id : $timelog->user_id
                             ]));
                         } ?>
                     </label>
@@ -52,7 +50,7 @@
                             "title"            => !empty($object) ? $object->getSelectOptionTitle() : null,
                             "value"            => !empty($timelog->object_id) ? $timelog->object_id : $tracking_id,
                             "required"        => "true"
-                        ]))->setOptions(!empty($usable_class) ? $w->Timelog->getObjects($usable_class, $where) : ''); ?>
+                        ]))->setOptions(!empty($usable_class) ? TimelogService::getInstance($w)->getObjects($usable_class, $where) : ''); ?>
                     </label>
                 </li>
                 <?php echo (new \Html\Form\InputField(["type" => "hidden", "id|name" => "object_id", "value" => $timelog->object_id ?: $tracking_id])); ?>

--- a/system/modules/timelog/timelog.hooks.php
+++ b/system/modules/timelog/timelog.hooks.php
@@ -1,13 +1,15 @@
 <?php
 
-function timelog_core_template_menu(Web $w) {
+function timelog_core_template_menu(Web $w)
+{
     if ($w->Timelog->shouldShowTimer()) {
         return $w->partial('timelogwidget', null, 'timelog');
     }
 }
 
 // delete any timelogs attached to deleted object
-function timelog_core_dbobject_after_delete($w, $obj) {
+function timelog_core_dbobject_after_delete($w, $obj)
+{
     $timelogs = $w->Timelog->getTimelogsForObject($obj);
     if (!empty($timelogs)) {
         foreach ($timelogs as $timelog) {


### PR DESCRIPTION
- Fixed an issue that was causing a user's Timelogs to be re-assigned to another admin user.
- Updated the Timelog's user field to be a select instead of an autocomplete to as part of the changes for the above fix.
- Removed the insert and update overrides on the Timelog object as part of changes for the fix on the first dot point.
- Added user_id as a required field on the Timelog object.
- Updated a task hook to fix bug with the default select value for time types inside the Timelog edit form.
- Did formatting on several files, removing commented code, unneeded white space, updating arrays to use the shorthand and updating service classes to use the new getInstance methods.

refs: 8875