### PR TITLE
Hotfix: Prevent adding task subscribers with insufficient view permissions

### DIFF
--- a/system/modules/task/actions/subscriber/add.php
+++ b/system/modules/task/actions/subscriber/add.php
@@ -81,12 +81,11 @@ function add_POST(Web $w)
         }
 
         if (!empty($contact->getUser())) {
-            $w->error('No user found for contact', '/task/edit/' . $task->id);
-            $w->Log->SetLogger("Contact id:" . $contact->id . ", residing in system without corrosponding user object"); 
-        }
-
-        if (!$task->canView($contact->getUser())) {
-            $w->error('Insufficient view permissions for user. Consider adding them to the relevant task group.', '/task/edit/' . $task->id);
+            if (!$contact->getUser()->is_external) {
+                if (!$task->canView($contact->getUser())) {
+                    $w->error('Insufficient view permissions for user. Consider adding them to the relevant task group.', '/task/edit/' . $task->id);
+                }
+            }
         }
 
         $user_id = $w->Auth->createExernalUserForContact($contact->id);

--- a/system/modules/task/actions/subscriber/add.php
+++ b/system/modules/task/actions/subscriber/add.php
@@ -27,9 +27,9 @@ function add_GET(Web $w)
             [[(new \Html\Form\Autocomplete())->setLabel('Contact')
                     ->setId('contact')
                     ->setName('contact')
-                    ->setOptions($contacts, function ($contacts) {
-                        $user = $contacts->getUser();
-                        return $contacts->getFullName() . ' - ' . $contacts->email . (empty($user->id) || $user->is_external == 1 ? ' (external)' : '');
+                    ->setOptions($contacts, function ($contact) {
+                        $user = $contact->getUser();
+                        return $contact->getFullName() . ' - ' . $contact->email . (empty($user->id) || $user->is_external == 1 ? ' (external)' : '');
                     }),
             ]],
         ],
@@ -80,12 +80,9 @@ function add_POST(Web $w)
             $w->error('Contact not found', '/task/edit/' . $task->id);
         }
 
-        if (!empty($contact->getUser())) {
-            if (!$contact->getUser()->is_external) {
-                if (!$task->canView($contact->getUser())) {
-                    $w->error('Insufficient view permissions for user. Consider adding them to the relevant task group.', '/task/edit/' . $task->id);
-                }
-            }
+        $user = $contact->getUser();
+        if (!empty($user) && !$user->is_external && !$task->canView($user)) {
+            $w->error('Insufficient view permissions for user. Consider adding them to the relevant task group.', '/task/edit/' . $task->id);
         }
 
         $user_id = $w->Auth->createExernalUserForContact($contact->id);

--- a/system/modules/task/actions/subscriber/add.php
+++ b/system/modules/task/actions/subscriber/add.php
@@ -27,9 +27,9 @@ function add_GET(Web $w)
             [[(new \Html\Form\Autocomplete())->setLabel('Contact')
                     ->setId('contact')
                     ->setName('contact')
-                    ->setOptions($contacts, function ($contact) {
-                        $user = $contact->getUser();
-                        return $contact->getFullName() . ' - ' . $contact->email . (empty($user->id) || $user->is_external == 1 ? ' (external)' : '');
+                    ->setOptions($contacts, function ($contacts) {
+                        $user = $contacts->getUser();
+                        return $contacts->getFullName() . ' - ' . $contacts->email . (empty($user->id) || $user->is_external == 1 ? ' (external)' : '');
                     }),
             ]],
         ],
@@ -78,6 +78,15 @@ function add_POST(Web $w)
         $contact = $w->Auth->getContact(intval($_POST['contact']));
         if (empty($contact->id)) {
             $w->error('Contact not found', '/task/edit/' . $task->id);
+        }
+
+        if (!empty($contact->getUser())) {
+            $w->error('No user found for contact', '/task/edit/' . $task->id);
+            $w->Log->SetLogger("Contact id:" . $contact->id . ", residing in system without corrosponding user object"); 
+        }
+
+        if (!$task->canView($contact->getUser())) {
+            $w->error('Insufficient view permissions for user. Consider adding them to the relevant task group.', '/task/edit/' . $task->id);
         }
 
         $user_id = $w->Auth->createExernalUserForContact($contact->id);

--- a/system/modules/task/models/TaskService.php
+++ b/system/modules/task/models/TaskService.php
@@ -10,6 +10,11 @@ class TaskService extends DbService
         return $this->getObject("TaskSubscriber", $subscriber_id);
     }
 
+    public function getSubscriberForUserAndTask($user_id, $task_id)
+    {
+        return $this->getObject("TaskSubscriber", ["is_deleted" => 0, "user_id" => $user_id, "task_id" => $task_id]);
+    }
+
     public function getTaskGroupDetailsForUser()
     {
         $user_id = $this->w->Auth->user()->id;

--- a/system/modules/task/models/TaskService.php
+++ b/system/modules/task/models/TaskService.php
@@ -438,7 +438,7 @@ class TaskService extends DbService
         }
 
         // if number of user role is >= number of requesite level, then allow
-        if (!empty($permission_array[$role]) && !empty($permission_array[$required_permission])) {
+        if (!empty($permission_array[$role]) && !is_null($permission_array[$required_permission])) {
             if ($permission_array[$role] >= $permission_array[$required_permission]) {
                 return true;
             }

--- a/system/modules/task/models/TaskService.php
+++ b/system/modules/task/models/TaskService.php
@@ -443,7 +443,7 @@ class TaskService extends DbService
         }
 
         // if number of user role is >= number of requesite level, then allow
-        if (!empty($permission_array[$role]) && !is_null($permission_array[$required_permission])) {
+        if (!empty($permission_array[$role]) && array_key_exists($required_permission, $permission_array)) {
             if ($permission_array[$role] >= $permission_array[$required_permission]) {
                 return true;
             }

--- a/system/modules/task/task.hooks.php
+++ b/system/modules/task/task.hooks.php
@@ -325,7 +325,6 @@ function task_core_dbobject_after_update_TaskGroup(Web $w, $object)
         foreach ($tasks as $task) {
             //Check if user is subscribed to the task & can no longer view it
             if ($task->isUserSubscribed($user->id) && !$task->canView($user)) {
-
                 //If so, remove subscription
                 TaskService::getInstance($w)->getSubscriberForUserAndTask($user->id, $task->id)->delete();
             }    

--- a/system/modules/task/task.hooks.php
+++ b/system/modules/task/task.hooks.php
@@ -316,4 +316,21 @@ function task_core_dbobject_after_update_TaskGroup(Web $w, $object)
             }
         }
     }
+
+    //Remove any subscribed users if they no longer have the sufficient view task permissions
+    $members = $object->getMembers();
+    foreach ($members as $member) {
+        $user = AuthService::getInstance($w)->getUser($member->user_id);
+        $tasks = $object->getTasks();
+        foreach ($tasks as $task) {
+            //Check if user is subscribed to the task & can no longer view it
+            if ($task->isUserSubscribed($user->id) && !$task->canView($user)) {
+
+                //If so, remove subscription
+                TaskService::getInstance($w)->getSubscriberForUserAndTask($user->id, $task->id)->delete();
+            }    
+        } 
+    }
+
+
 }


### PR DESCRIPTION
- Added a check & error if the subscribed user has permissions to view the given task
- Added a hook to check if users still can view even after task group permission changes
- Task group permission check now works for the "ALL" role