### PR TITLE
fix: Search results returning headers with no content

### DIFF
--- a/system/modules/search/actions/results.php
+++ b/system/modules/search/actions/results.php
@@ -36,21 +36,32 @@ function results_GET(Web $w)
 
                 foreach ($filter_results as $class => $objects) {
                     // Transform class into readable text
-                    $t_class = preg_replace('/(?<=\\w)(?=[A-Z])/', " $1", $class);
-                    $buffer .= "<div class='row search-class'><h4 style='padding-top: 10px; font-weight: lighter;'>{$t_class}</h4>";
-
+                    $canDisplay = true;
                     if (!empty($objects)) {
                         foreach ($objects as $object) {
                             if ($object->canList($w->Auth->user())) {
+                                
                                 $buffer .= '<div class="panel search-result">';
                                 if ($object->canView($w->Auth->user())) {
                                     $buffer .= "<a class=row search-title href=" . $w->localUrl($object->printSearchUrl()) . ">{$object->printSearchTitle()}</a>"
                                         . "<div class=row search-listing>{$object->printSearchListing()}</div>";
                                 } else {
+                                    $canDisplay = false;
                                     $buffer .= "<div class=small-12 columns search-title>{$object->printSearchTitle()}</div><div class=row search-listing>(restricted)</div>";
-                                }
+                                } 
                                 $buffer .= "</div>";
-                            }
+                            } else {
+                                $canDisplay = false;
+                           }
+                        }
+
+                        if ($canDisplay == false) {
+                            $buffer .= "Insufficient permissions";
+                        } else {
+                            $t_class = preg_replace('/(?<=\\w)(?=[A-Z])/', " $1", $class);
+                            $header = "<div class='row search-class'><h4 style='padding-top: 10px; font-weight: lighter;'>{$t_class}</h4>"; 
+
+                            $buffer = $header . $buffer;
                         }
                     }
                     $buffer .= "</div>";

--- a/system/modules/search/actions/results.php
+++ b/system/modules/search/actions/results.php
@@ -1,77 +1,81 @@
 <?php
+
 function results_GET(Web $w)
 {
-    $response = array("success" => true, "data" => "");
+    $response = ["success" => true, "data" => ""];
     $w->setLayout(null);
-    $q = $w->request('q'); // query
-    $idx = $w->request('idx'); // index
-    $p = $w->request('p'); // page
-    $ps = $w->request('ps'); // pageSize
-    $tr = $w->request('tr'); // total results
-    $tags = $w->request('tags'); // Tags
+    $query = $w->request('q');
+    $index = $w->request('idx');
+    $page = $w->request('p');
+    $page_size = $w->request('ps');
+    $total_results = $w->request('tr');
+    $tags = $w->request('tags');
 
-    if (($q && strlen($q) >= 3) || (!empty($tags))) {
+    if (($query && strlen($query) >= 3) || (!empty($tags))) {
         if (!empty($tags)) {
             if (is_array($tags)) {
                 foreach ($tags as $tag) {
-                    $q .= ' unitag' . strtolower(preg_replace('%[^a-z]%i', '', $tag));
+                    $query .= ' unitag' . strtolower(preg_replace('%[^a-z]%i', '', $tag));
                 }
             } else {
-                $q .= ' unitag' . strtolower(preg_replace('%[^a-z]%i', '', $tags));
+                $query .= ' unitag' . strtolower(preg_replace('%[^a-z]%i', '', $tags));
             }
         }
-        $results = $w->Search->getResults($q, $idx, $p, $ps);
 
-        if (empty($p) && empty($ps) && empty($tr)) {
+        $results = SearchService::getInstance($w)->getResults($query, $index, $page, $page_size);
+
+        if (empty($page) && empty($page_size) && empty($total_results)) {
             $buffer = "";
             if (!empty($results[0])) {
-                // Group results by class_name
-                $filter_results = array();
+                $filter_results = [];
+
+                // Group results by class_name.
                 foreach ($results[0] as $res) {
-                    $searchobject = $w->Search->getObject($res['class_name'], $res['object_id']);
+                    $searchobject = SearchService::getInstance($w)->getObject($res['class_name'], $res['object_id']);
                     if (!empty($searchobject)) {
                         $filter_results[$res['class_name']][] = $searchobject;
                     }
                 }
 
                 foreach ($filter_results as $class => $objects) {
-                    // Transform class into readable text
-                    $canDisplay = true;
+                    $title_added = false;
+
                     if (!empty($objects)) {
                         foreach ($objects as $object) {
-                            if ($object->canList($w->Auth->user())) {
-                                
-                                $buffer .= '<div class="panel search-result">';
-                                if ($object->canView($w->Auth->user())) {
-                                    $buffer .= "<a class=row search-title href=" . $w->localUrl($object->printSearchUrl()) . ">{$object->printSearchTitle()}</a>"
-                                        . "<div class=row search-listing>{$object->printSearchListing()}</div>";
-                                } else {
-                                    $canDisplay = false;
-                                    $buffer .= "<div class=small-12 columns search-title>{$object->printSearchTitle()}</div><div class=row search-listing>(restricted)</div>";
-                                } 
-                                $buffer .= "</div>";
+                            if (!$object->canList(AuthService::getInstance($w)->user())) {
+                                continue;
+                            }
+
+                            // Only add the title once after we know at least one object can be listed.
+                            if (!$title_added) {
+                                $t_class = preg_replace('/(?<=\\w)(?=[A-Z])/', " $1", $class);
+                                $buffer .= "<div class='row search-class'><h4 style='padding-top: 10px; font-weight: lighter;'>{$t_class}</h4>";
+                                $title_added = true;
+                            }
+
+                            $buffer .= '<div class="panel search-result">';
+
+                            if ($object->canView(AuthService::getInstance($w)->user())) {
+                                $buffer .= "<a class=row search-title href=" . $w->localUrl($object->printSearchUrl()) . ">{$object->printSearchTitle()}</a>"
+                                    . "<div class=row search-listing>{$object->printSearchListing()}</div>";
                             } else {
-                                $canDisplay = false;
-                           }
-                        }
+                                $buffer .= "<div class=small-12 columns search-title>{$object->printSearchTitle()}</div><div class=row search-listing>(restricted)</div>";
+                            }
 
-                        if ($canDisplay == false) {
-                            $buffer .= "Insufficient permissions";
-                        } else {
-                            $t_class = preg_replace('/(?<=\\w)(?=[A-Z])/', " $1", $class);
-                            $header = "<div class='row search-class'><h4 style='padding-top: 10px; font-weight: lighter;'>{$t_class}</h4>"; 
-
-                            $buffer = $header . $buffer;
+                            $buffer .= "</div>";
                         }
                     }
+
                     $buffer .= "</div>";
                 }
             }
+
             $response["data"] = $buffer;
         }
     } else {
         $response["success"] = false;
         $response["data"] = "Please enter at least 3 characters for searching.";
     }
+
     $w->out(json_encode($response));
 }


### PR DESCRIPTION
- Added a check so the headers in the search results are only added if the users have permission to view the content of the results

refs: 7881