### PR TITLE
feat: View 2FA Secret

### DIFF
--- a/system/modules/admin/templates/user/edit.tpl.php
+++ b/system/modules/admin/templates/user/edit.tpl.php
@@ -164,7 +164,10 @@
                         <button v-if="!user.security.is_mfa_enabled && mfa_qr_code_url === null" class="tiny success" @click="getMfaQrCode" :disabled="is_loading">Enable</button>
                         <button v-if="user.security.is_mfa_enabled" class="tiny alert" @click="disableMfa" :disabled="is_loading">Disable</button>
                         <div v-if="mfa_qr_code_url !== null">
-                            <img v-if="show_qr_code" :src="mfa_qr_code_url" width="250" height="250">
+                            <div v-if="show_qr_code">
+                                <img :src="mfa_qr_code_url" width="250" height="250">
+                                <label style="margin-top: 4px;">{{ mfa_secret }}</label>
+                            </div>
                             <button v-else class="tiny" @click="show_qr_code = true">Show QR Code</button>
                             <form>
                                 <label>Code
@@ -204,6 +207,7 @@
             return {
                 user: <?php echo json_encode($user); ?>,
                 mfa_code: "",
+                mfa_secret: "",
                 mfa_qr_code_url: null,
                 show_qr_code: false,
                 is_confirming_code: false,
@@ -320,6 +324,7 @@
                     }
 
                     _this.mfa_qr_code_url = response.data.qr_code;
+                    _this.mfa_secret = response.data.mfa_secret;
                 }).catch(function(error) {
                     new Toast("Failed to fetch QR Code").show();
                     console.log(error);
@@ -347,6 +352,7 @@
                     }
 
                     _this.mfa_qr_code_url = null;
+                    _this.mfa_secret = null;
                     _this.user.security.is_mfa_enabled = true;
                     new Toast("2FA enabled").show();
                 }).catch(function(error) {

--- a/system/modules/admin/templates/user/edit.tpl.php
+++ b/system/modules/admin/templates/user/edit.tpl.php
@@ -166,7 +166,8 @@
                         <div v-if="mfa_qr_code_url !== null">
                             <div v-if="show_qr_code">
                                 <img :src="mfa_qr_code_url" width="250" height="250">
-                                <label style="margin-top: 4px;">{{ mfa_secret }}</label>
+                                <label style="margin-top: 4px;">Can't scan the code? Add it manually.</label>
+                                <label>{{ mfa_secret }}</label>
                             </div>
                             <button v-else class="tiny" @click="show_qr_code = true">Show QR Code</button>
                             <form>

--- a/system/modules/auth/actions/ajax_get_mfa_qr_code.php
+++ b/system/modules/auth/actions/ajax_get_mfa_qr_code.php
@@ -27,5 +27,5 @@ function ajax_get_mfa_qr_code_GET(Web $w)
         return;
     }
 
-    $w->out((new AxiosResponse())->setSuccessfulResponse("User details updated", ["qr_code" => $qr_code]));
+    $w->out((new AxiosResponse())->setSuccessfulResponse("User details updated", ["qr_code" => $qr_code, "mfa_secret" => chunk_split($user->mfa_secret, 4, " ")]));
 }

--- a/system/modules/auth/templates/profile.tpl.php
+++ b/system/modules/auth/templates/profile.tpl.php
@@ -139,7 +139,8 @@ $w->setLayout("layout")
                         <div v-if="mfa_qr_code_url !== null">
                             <div v-if="show_qr_code">
                                 <img :src="mfa_qr_code_url" width="250" height="250">
-                                <label style="margin-top: 4px;">{{ mfa_secret }}</label>
+                                <label style="margin-top: 4px;">Can't scan the code? Add it manually.</label>
+                                <label>{{ mfa_secret }}</label>
                             </div>
                             <button v-else class="tiny" @click="show_qr_code = true">Show QR Code</button>
                             <form>

--- a/system/modules/auth/templates/profile.tpl.php
+++ b/system/modules/auth/templates/profile.tpl.php
@@ -137,7 +137,10 @@ $w->setLayout("layout")
                         <button v-if="!user.security.is_mfa_enabled && mfa_qr_code_url === null" class="tiny success" @click="getMfaQrCode" :disabled="is_loading">Enable</button>
                         <button v-if="user.security.is_mfa_enabled" class="tiny alert" @click="disableMfa" :disabled="is_loading">Disable</button>
                         <div v-if="mfa_qr_code_url !== null">
-                            <img v-if="show_qr_code" :src="mfa_qr_code_url" width="250" height="250">
+                            <div v-if="show_qr_code">
+                                <img :src="mfa_qr_code_url" width="250" height="250">
+                                <label style="margin-top: 4px;">{{ mfa_secret }}</label>
+                            </div>
                             <button v-else class="tiny" @click="show_qr_code = true">Show QR Code</button>
                             <form>
                                 <label>Code
@@ -167,6 +170,7 @@ $w->setLayout("layout")
             return {
                 user: <?php echo json_encode($user); ?>,
                 mfa_code: "",
+                mfa_secret: "",
                 mfa_qr_code_url: null,
                 show_qr_code: false,
                 is_confirming_code: false,
@@ -256,6 +260,7 @@ $w->setLayout("layout")
                     }
 
                     _this.mfa_qr_code_url = response.data.qr_code;
+                    _this.mfa_secret = response.data.mfa_secret;
                 }).catch(function(error) {
                     new Toast("Failed to fetch QR Code").show();
                     console.log(error);
@@ -283,6 +288,7 @@ $w->setLayout("layout")
                     }
 
                     _this.mfa_qr_code_url = null;
+                    _this.mfa_secret = null;
                     _this.user.security.is_mfa_enabled = true;
                     new Toast("2FA enabled").show();
                 }).catch(function(error) {


### PR DESCRIPTION
Added the ability to view a 2FA secret when enabling 2FA. This can be useful if a User's phone is unable to scan the QR code and needs to set it up manually.

refs: 9075