### PR TITLE
fix: Add checks for variables that quote() is used on

### DIFF
--- a/system/modules/report/models/ReportService.php
+++ b/system/modules/report/models/ReportService.php
@@ -176,7 +176,7 @@ class ReportService extends DbService
 
         // this sql below statement may not be as nifty as the above .. but it works!
         $rows = $this->_db->sql("SELECT distinct r.* from " . ReportMember::$_db_table . " as m inner join " .
-            Report::$_db_table . " as r on m.report_id = r.id where m.user_id in (" . $this->_db->quote($theid) . ") " . $this->_db->quote($where) .
+            Report::$_db_table . " as r on m.report_id = r.id where m.user_id in (" . $this->_db->quote($theid) . ") " . (!empty($where) ? $this->_db->quote($where) : '') .
             " and r.is_deleted = 0 order by r.is_approved desc,r.title")->fetch_all();
         return $this->fillObjects("Report", $rows);
     }

--- a/system/modules/task/models/TaskService.php
+++ b/system/modules/task/models/TaskService.php
@@ -520,6 +520,7 @@ class TaskService extends DbService
     // required to join with modifiable aspect to determine task creator
     public function getCreatorTasks($id, $clause = null)
     {
+        $where = '';
         if (is_array($clause)) {
             foreach ($clause as $name => $value) {
                 $where .= "and t." . $name . " = '" . $value . "' ";


### PR DESCRIPTION
An issue was discovered where report lists could not be produced. It looks like that quote is running on an empty variable, producing bad sql.
Needs verification.