### PR TITLE
fix: corrected quoted SQL times

### DIFF
--- a/system/modules/admin/models/AuditService.php
+++ b/system/modules/admin/models/AuditService.php
@@ -22,8 +22,10 @@ class AuditService extends DbService
         // is in the list
         if ($blacklist) {
             foreach ($blacklist as $line) {
-                if ($line[0] == $this->w->currentModule() &&
-                    ($line[1] == $this->w->currentAction() || $line[1] == "*")) {
+                if (
+                    $line[0] == $this->w->currentModule() &&
+                    ($line[1] == $this->w->currentAction() || $line[1] == "*")
+                ) {
                     return;
                 }
             }
@@ -91,8 +93,8 @@ class AuditService extends DbService
      */
     public function getLoggedInUsers($idleMinutes = 10)
     {
-        $users = array();
-        $stmt = "SELECT distinct creator_id FROM audit where timediff(now(), dt_created) < '00:" . $this->_db->quote($idleMinutes) . ":00' and creator_id > 0";
+        $users = [];
+        $stmt = "SELECT distinct creator_id FROM audit where timediff(now(), dt_created) < " . $this->_db->quote("00:" . $idleMinutes  . ":00") . " and creator_id > 0";
         $res = $this->_db->sql($stmt)->fetch_all();
         if ($res && sizeof($res)) {
             foreach ($res as $row) {
@@ -101,5 +103,4 @@ class AuditService extends DbService
         }
         return $users;
     }
-
 }


### PR DESCRIPTION
Fixes 'random'/periodic? DB error
Thrown when auth audit service polls idle session times.
Relates to changes on SQL injection defence.
Reordered single quotes to fix.

refs:
issues: