### PR TITLE
fix: Custom MailObject SendFrom Vs Replyto

### DIFF
--- a/system/modules/inbox/models/InboxService.php
+++ b/system/modules/inbox/models/InboxService.php
@@ -47,6 +47,7 @@ class InboxService extends DbService {
     }
 
     function sendMail($to, $cc, $bcc, $from, $replyto, $subject, $message) {
+        $this->w->Log->info("Inbox service is asserting retired mail system");
         $mailconf = Config::get('inbox.phpmailer');//$this->w->moduleConf("inbox", "phpmailer");
 
         if ($mailconf) {

--- a/system/modules/inbox/models/InboxService.php
+++ b/system/modules/inbox/models/InboxService.php
@@ -47,7 +47,7 @@ class InboxService extends DbService {
     }
 
     function sendMail($to, $cc, $bcc, $from, $replyto, $subject, $message) {
-        $this->w->Log->info("Inbox service is asserting retired mail system");
+        LogService::getInstance($this->w)->info("Inbox service is asserting retired mail system");
         $mailconf = Config::get('inbox.phpmailer');//$this->w->moduleConf("inbox", "phpmailer");
 
         if ($mailconf) {

--- a/system/modules/task/actions/edit.php
+++ b/system/modules/task/actions/edit.php
@@ -280,7 +280,7 @@ function edit_POST($w)
 
         $messageObject = new Swift_Message("Invite to: " . $task->title);
         $messageObject->setTo([$contact->email]);
-        $messageObject->setReplyTo([$w->Auth->user()->getContact()->email])
+        $messageObject->setReplyTo([AuthService::getInstance($w)->user()->getContact()->email])
         ->setFrom(Config::get("main.company_support_email"));
 
         $messageObject->addPart("Your iCal is attached<br/><br/><a href='http://www.google.com/calendar/event?action=TEMPLATE&text={$task->title}" .

--- a/system/modules/task/actions/edit.php
+++ b/system/modules/task/actions/edit.php
@@ -280,7 +280,8 @@ function edit_POST($w)
 
         $messageObject = new Swift_Message("Invite to: " . $task->title);
         $messageObject->setTo([$contact->email]);
-        $messageObject->setFrom($w->Auth->user()->getContact()->email);
+        $messageObject->setReplyTo([$w->Auth->user()->getContact()->email])
+        ->setFrom(Config::get("main.company_support_email"));
 
         $messageObject->addPart("Your iCal is attached<br/><br/><a href='http://www.google.com/calendar/event?action=TEMPLATE&text={$task->title}" .
             "&dates=" . date("Ymd", strtotime(str_replace('/', '-', $task->dt_due))) . "/" . date("Ymd", strtotime(str_replace('/', '-', $task->dt_due))) .

--- a/system/modules/timelog/models/TimelogService.php
+++ b/system/modules/timelog/models/TimelogService.php
@@ -128,7 +128,7 @@ class TimelogService extends DbService {
 
     public function shouldShowTimer() {
         // Check if tracking object set or existing timelog is running
-        return ($this->w->Auth->user()->hasRole("timelog_user") && ($this->hasTrackingObject() || $this->hasActiveLog()));
+        return ((!empty($this->w->Auth->user())) && $this->w->Auth->user()->hasRole("timelog_user") && ($this->hasTrackingObject() || $this->hasActiveLog()));
     }
 
     /**

--- a/system/modules/timelog/models/TimelogService.php
+++ b/system/modules/timelog/models/TimelogService.php
@@ -127,8 +127,8 @@ class TimelogService extends DbService {
     }
 
     public function shouldShowTimer() {
-        // Check if tracking object set or existing timelog is running
-        return ((!empty($this->w->Auth->user())) && $this->w->Auth->user()->hasRole("timelog_user") && ($this->hasTrackingObject() || $this->hasActiveLog()));
+        // Check if tracking object set or existing timelog is running        
+        return ((!empty(AuthService::getInstance($this->w)->user())) && AuthService::getInstance($this->w)->user()->hasRole("timelog_user") && ($this->hasTrackingObject() || $this->hasActiveLog()));
     }
 
     /**


### PR DESCRIPTION
Check & patch anywhere a custom mailer bypasses transport->send
hence can be setting it's own 'from'
Make sure 'from' is 'company'
(Also patch for cron action fall through to default .tpl on ShowTimer)

refs: Client post SES transition
issues:
