### PR TITLE
fix: Report Service

### DIFF
--- a/system/modules/report/actions/exereport.php
+++ b/system/modules/report/actions/exereport.php
@@ -27,6 +27,10 @@ function exereport_ALL(Web &$w) {
     if (!empty($p['id'])) {
         // get member
         $member = $w->Report->getReportMember($p['id'], $w->session('user_id'));
+        if (empty($member)) {
+            $w->ctx("showreport", "No Report for user");
+            return;
+        }
 
         // get the relevant report
         $rep = $w->Report->getReportInfo($p['id']);

--- a/system/modules/report/models/ReportService.php
+++ b/system/modules/report/models/ReportService.php
@@ -144,25 +144,48 @@ class ReportService extends DbService
     {
 
         // Clause for admin user
-        if ($this->w->Auth->user()->hasRole("report_admin")) {
+        if (AuthService::getInstance($this->w)->user()->hasRole("report_admin")) {
             return $this->getReports();
         }
 
         // need to get reports for me and my groups
         // me
-        $myid = [$id];
+        $myid[] = $this->_db->quote($id);
 
         // need to check all groups given group member could be a group
-        $groups = $this->w->Auth->getGroups();
+        $groups = AuthService::getInstance($this->w)->getGroups();
 
         foreach ($groups ?? [] as $group) {
-            if ($this->w->Auth->user()->inGroup($group)) {
-                $myid[$group->id] = $group->id;
+            if (AuthService::getInstance($this->w)->user()->inGroup($group)) {
+                $myid[$group->id] = $this->_db->quote($group->id);
             }
         }
 
         // list of IDs to check for report membership, my ID and my group IDs
         $theid = implode(",", $myid);
+        
+        // adapt if we were given raw SQL!
+        if (!is_array($where)) {
+            // assume we only check a single equality/pair
+            $spec = explode("=", $where);
+            // anything else will be turned to mush
+            $column = explode(" ", trim($spec[0]));
+            $column = explode(".", end($column));
+            $match = trim(end($spec));
+            $match = str_replace("'", "", $match);
+            $where = [
+                end($column) => $match
+            ];
+        }
+        $filter="";
+        // enforce literal quoted match as r.[columnName] = 'something'
+        foreach ($where as $term => $check) {
+            if (!empty($check)) {
+                $tmp=explode(".", $term);
+                $term=trim(end($tmp));
+                $filter .= " and r.".$term." = ".$this->_db->quote($check)." ";
+            }
+        } //var_dump($filter);
 
         // the sql statement below return duplicate reports if they have multiple members
 
@@ -176,8 +199,10 @@ class ReportService extends DbService
 
         // this sql below statement may not be as nifty as the above .. but it works!
         $rows = $this->_db->sql("SELECT distinct r.* from " . ReportMember::$_db_table . " as m inner join " .
-            Report::$_db_table . " as r on m.report_id = r.id where m.user_id in (" . $this->_db->quote($theid) . ") " . (!empty($where) ? $this->_db->quote($where) : '') .
-            " and r.is_deleted = 0 order by r.is_approved desc,r.title")->fetch_all();
+            Report::$_db_table . " as r on m.report_id = r.id " .
+            " where m.user_id in (" . $theid . ") " . $filter .
+            " and r.is_deleted = 0 and m.is_deleted = 0 " .
+            " order by r.is_approved desc,r.title")->fetch_all();
         return $this->fillObjects("Report", $rows);
     }
 

--- a/system/modules/report/models/ReportService.php
+++ b/system/modules/report/models/ReportService.php
@@ -36,6 +36,7 @@ class ReportService extends DbService
                 $conferred[] = $this->getObject("ReportMember", ["report_id" => $id, "user_id" => $group->id, "is_deleted" => 0]);
             }
         }
+        $conferred = array_filter($conferred);
         return end($conferred);
     }
 
@@ -159,7 +160,7 @@ class ReportService extends DbService
 
         // need to get reports for me and my groups
         // me
-        $myid[] = $this->_db->quote($id);
+        $myid = [$this->_db->quote($id)];
 
         // need to check all groups given group member could be a group
         $groups = AuthService::getInstance($this->w)->getGroups();
@@ -194,8 +195,15 @@ class ReportService extends DbService
         return $this->fillObjects("Report", $rows);
     }
 
-     public function unitaryWhereToAndClause($where) {
-           
+    /**
+     * unitary approach to form an 'and' clause for 'where' from text or key values
+     *
+     * @param string $where
+     * @param array $where
+     * @return string
+     */
+    public function unitaryWhereToAndClause($where)
+    {
         // adapt if we were given raw SQL!
         if (!is_array($where)) {
             // assume we only check a single equality/pair
@@ -223,9 +231,9 @@ class ReportService extends DbService
                 $term = str_replace(";", "", $term);
                 $filter .= " and r.".$term." = ".$this->_db->quote($check)." ";
             }
-        } 
+        }
         return $filter;
-     }
+    }
     // return list of APPROVED and NOT DELETED report IDs for a given a user ID as member
     public function getReportsbyUserId($id)
     {

--- a/system/modules/report/tests/unit/ReportModuleUnit.php
+++ b/system/modules/report/tests/unit/ReportModuleUnit.php
@@ -1,0 +1,103 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ReportModuleUnit extends TestCase //\Codeception\Test\Unit
+{
+    public function testSQLI()
+    {
+        require_once("system/web.php");
+
+        $w = new Web();
+        $w->initDB();
+
+        $serve = ReportService::getInstance($w);
+
+        // non malicious cases:  $and = $serve->unitaryWhereToAndClause($sqli);
+
+        $and = $serve->unitaryWhereToAndClause("");
+        echo $and."\n";
+        $this->assertSame($and, "");
+
+        $try = [
+            "and dog=cat",
+            "dog=cat",
+            "and reportthing.dog = cat",
+            "'dog=cat'",
+            "'dog'='cat'",
+            "dog='cat'",
+        ];
+        foreach ($try as $sqli) {
+            $and = $serve->unitaryWhereToAndClause($sqli);
+            echo $and."\n";
+            $this->assertSame($and, " and r.dog = 'cat' ");
+        }
+
+
+        $try = [
+            ["dog" => "cat"],
+            ["reportingthing.dog" => "cat"],
+            ["'dog'" => "'cat'"],
+            ["'dog'" => "cat"],
+            ["dog" => "'cat'"],
+
+        ];
+        foreach ($try as $sqli) {
+            $and = $serve->unitaryWhereToAndClause($sqli);
+            echo $and."\n";
+            $this->assertSame($and, " and r.dog = 'cat' ");
+        }
+
+        $try=
+        [
+            "dog" => "cat",
+            "pig" => "fish",
+        ];
+        $and = $serve->unitaryWhereToAndClause($try);
+        echo $and."\n";
+        $this->assertSame($and, " and r.dog = 'cat'  and r.pig = 'fish' ");
+
+        //  malicious cases:  $and = $serve->unitaryWhereToAndClause($sqli);
+
+        $and = $serve->unitaryWhereToAndClause("");
+        echo $and."\n";
+        $this->assertSame($and, "");
+
+        $try = [
+            "';run SQL--",
+            "id = r.id",
+            [
+                "id = r.id or 1=1 or 1" => "r.id"
+            ]
+        ];
+        foreach ($try as $sqli) {
+            $and = $serve->unitaryWhereToAndClause($sqli);
+            echo $and."\n";
+            $terms = explode("=",str_replace(" and ","",$and));
+            $this->assertEquals(count($terms),2);
+            $this->assertEquals(substr(trim($terms[1]),0,1),"'");
+            $this->assertEquals(substr(trim($terms[1]),-1,1),"'");
+            $terms = explode(".",$terms[0]);
+            $this->assertEquals(count($terms),2);
+            $terms = explode(" ",trim($terms[1]));
+            $this->assertEquals(count($terms),1);
+
+           // $this->assertSame($and, " and r.dog = 'cat' ");
+        }
+
+
+        // $try = [
+        //     ["dog" => "cat"],
+        //     ["reportingthing.dog" => "cat"],
+        //     ["'dog'" => "'cat'"],
+        //     ["'dog'" => "cat"],
+        //     ["dog" => "'cat'"],
+
+        // ];
+        // foreach ($try as $sqli) {
+        //     $and = $serve->unitaryWhereToAndClause($sqli);
+        //     echo $and."\n";
+        //     $this->assertSame($and, " and r.dog = 'cat' ");
+        // }
+    }
+}

--- a/system/modules/report/tests/unit/ReportModuleUnit.php
+++ b/system/modules/report/tests/unit/ReportModuleUnit.php
@@ -82,22 +82,7 @@ class ReportModuleUnit extends TestCase //\Codeception\Test\Unit
             $terms = explode(" ",trim($terms[1]));
             $this->assertEquals(count($terms),1);
 
-           // $this->assertSame($and, " and r.dog = 'cat' ");
         }
 
-
-        // $try = [
-        //     ["dog" => "cat"],
-        //     ["reportingthing.dog" => "cat"],
-        //     ["'dog'" => "'cat'"],
-        //     ["'dog'" => "cat"],
-        //     ["dog" => "'cat'"],
-
-        // ];
-        // foreach ($try as $sqli) {
-        //     $and = $serve->unitaryWhereToAndClause($sqli);
-        //     echo $and."\n";
-        //     $this->assertSame($and, " and r.dog = 'cat' ");
-        // }
     }
 }


### PR DESCRIPTION
Good UserWhere From AllCalls

Report UserWhere being called by array, string and 'empty'
Then breaking anyway due to incorrect quote escapes
Fixes for versatile calls & forced SQL escaping
Tested Support:
/report/index?module=
/report/reportAjaxCategorytoType?id=_
/report/reportAjaxListModules

refs: clients assert reports dont work
