### PR TITLE
feat: pagination via days rather than raw timelog entries

### DIFF
--- a/system/modules/timelog/actions/index.php
+++ b/system/modules/timelog/actions/index.php
@@ -5,18 +5,18 @@ define('TIMELOG_DEFAULT_PAGE_SIZE', 20);
 
 function index_GET(Web $w) {
     $page = $w->request("p", TIMELOG_DEFAULT_PAGE);
-    $pagesize = $w->request("ps", TIMELOG_DEFAULT_PAGE_SIZE);
+    $page_size = $w->request("ps", TIMELOG_DEFAULT_PAGE_SIZE);
     
     //Get days in their 10 day groupings
-    $daysWithTimelogs = TimelogService::getInstance($w)->DaysForTimelogs($w->Auth->user());
+    $days_with_timelogs = TimelogService::getInstance($w)->daysForTimelogs($w->Auth->user());
     //Get the day group corrosponding to the current page
-    $pageBracket = $daysWithTimelogs[$page - 1];
+    $page_bracket = $days_with_timelogs[$page - 1];
     //Get timelogs to display that belong to the corrosponding 10 days
-    $timelog = TimelogService::getInstance($w)->getTimelogsForUser($w->Auth->user(), false, $pageBracket[count($pageBracket) - 1], $pageBracket[0]);
+    $timelog = TimelogService::getInstance($w)->getTimelogsForUser($w->Auth->user(), false, $page_bracket[count($page_bracket) - 1], $page_bracket[0]);
 
-    $totalresults = TimelogService::getInstance($w)->countTotalTimelogsForUser($w->Auth->user(), false);
+    $total_results = TimelogService::getInstance($w)->countTotalTimelogsForUser($w->Auth->user(), false);
 
-    $w->ctx('pagination', Html::pagination($page, (count($daysWithTimelogs)), $pagesize, ($totalresults), '/timelog'));
+    $w->ctx('pagination', Html::pagination($page, (count($days_with_timelogs)), $page_size, ($total_results), '/timelog'));
     
     $time_entry_objects = [];
 

--- a/system/modules/timelog/actions/index.php
+++ b/system/modules/timelog/actions/index.php
@@ -7,8 +7,11 @@ function index_GET(Web $w) {
     $page = $w->request("p", TIMELOG_DEFAULT_PAGE);
     $pagesize = $w->request("ps", TIMELOG_DEFAULT_PAGE_SIZE);
     
+    //Get days in their 10 day groupings
     $daysWithTimelogs = TimelogService::getInstance($w)->DaysForTimelogs($w->Auth->user());
+    //Get the day group corrosponding to the current page
     $pageBracket = $daysWithTimelogs[$page - 1];
+    //Get timelogs to display that belong to the corrosponding 10 days
     $timelog = TimelogService::getInstance($w)->getTimelogsForUser($w->Auth->user(), false, $pageBracket[count($pageBracket) - 1], $pageBracket[0]);
 
     $totalresults = TimelogService::getInstance($w)->countTotalTimelogsForUser($w->Auth->user(), false);

--- a/system/modules/timelog/models/TimelogService.php
+++ b/system/modules/timelog/models/TimelogService.php
@@ -186,6 +186,7 @@ class TimelogService extends DbService {
         return $nav;
     }
 
+    //Returns an array of timelogs in groups of 10 days
     public function daysForTimelogs($user) {
         $timelogs = $this->timelog->getTimelogsForUser($user);
         $previousTimelog = null;

--- a/system/modules/timelog/models/TimelogService.php
+++ b/system/modules/timelog/models/TimelogService.php
@@ -15,37 +15,37 @@ class TimelogService extends DbService {
      * @param boolean $includeDeleted
      * @return Timelog
      */
-    public function getTimelogsForUser(User $user = null, $includeDeleted = false, $timeStart = null, $timeEnd = null) {
+    public function getTimelogsForUser(User $user = null, $include_deleted = false, $time_start = null, $time_end = null) {
        
         if ($user === null) {
             $user = $this->w->Auth->user();
         }
 
         $where = ['user_id' => $user->id];
-        if (!$includeDeleted) {
+        if (!$include_deleted) {
             $where['is_deleted'] = 0;
         }
 
-        if (!empty($timeStart) && !empty($timeEnd)) {
-            $bracketStart = $timeStart->dt_start;
-            $startCondition = date('Y-m-d H:i:s', $bracketStart);
-            $where['dt_start >= ?'] = $startCondition;
+        if (!empty($time_start) && !empty($time_end)) {
+            $bracket_start = $time_start->dt_start;
+            $start_condition = date('Y-m-d H:i:s', $bracket_start);
+            $where['dt_start >= ?'] = $start_condition;
             
-            $bracketEnd = $timeEnd->dt_end;
-            $endCondition = date('Y-m-d H:i:s', $bracketEnd);
-            $where['dt_start <= ?'] = $endCondition;
+            $bracket_end = $time_end->dt_end;
+            $end_condition = date('Y-m-d H:i:s', $bracket_end);
+            $where['dt_start <= ?'] = $end_condition;
         }
 
         return $this->getObjects("Timelog", $where, false, true, "dt_start DESC", null, 100);
     }
 
-    public function countTotalTimelogsForUser(User $user = null, $includeDeleted = false) {
+    public function countTotalTimelogsForUser(User $user = null, $include_deleted = false) {
         if ($user === null) {
             $user = $this->w->Auth->user();
         }
 
         $where = ['user_id' => $user->id];
-        if (!$includeDeleted) {
+        if (!$include_deleted) {
             $where['is_deleted'] = 0;
         }
 
@@ -175,11 +175,11 @@ class TimelogService extends DbService {
 
         $nav = $nav ? : array();
 
-        $trackingObject = $w->Timelog->getTrackingObject();
+        $tracking_object = $w->Timelog->getTrackingObject();
 
         if ($w->Auth->loggedIn()) {
             $w->menuLink("timelog/index", "Timelog Dashboard", $nav);
-            $w->menuBox("timelog/edit" . (!empty($trackingObject) && !empty($trackingObject->id) ? "?class=" . get_class($trackingObject) . "&id=" . $trackingObject->id : ''), "Add Timelog", $nav);
+            $w->menuBox("timelog/edit" . (!empty($tracking_object) && !empty($tracking_object->id) ? "?class=" . get_class($tracking_object) . "&id=" . $tracking_object->id : ''), "Add Timelog", $nav);
         }
 
         $w->ctx("navigation", $nav);
@@ -189,32 +189,32 @@ class TimelogService extends DbService {
     //Returns an array of timelogs in groups of 10 days
     public function daysForTimelogs($user) {
         $timelogs = $this->timelog->getTimelogsForUser($user);
-        $previousTimelog = null;
-        $currentTimelog = null;
+        $previous_timelog = null;
+        $current_timelog = null;
 
-        $daysWithLogs = [];
+        $days_with_logs = [];
         $i = 0;
-        $subsetCount = -1;
+        $subset_count = -1;
 
         foreach ($timelogs as $timelog) {
-            $currentTimelog = $timelog;
-            if ($previousTimelog != null) {
-                $date = $currentTimelog->dt_start;
-                $previousDate = $previousTimelog->dt_start;
+            $current_timelog = $timelog;
+            if ($previous_timelog != null) {
+                $date = $current_timelog->dt_start;
+                $previous_date = $previous_timelog->dt_start;
 
-                $result = date('d', $date) === date('d', $previousDate);
+                $result = date('d', $date) === date('d', $previous_date);
 
                 if ($result == false) {
                     if ($i % 10 == 0) {
-                        $subsetCount += 1;
+                        $subset_count += 1;
                     }
 
-                    $daysWithLogs[$subsetCount][] = $timelog;
+                    $days_with_logs[$subset_count][] = $timelog;
                     $i += 1;
                 }
             }
-            $previousTimelog = $currentTimelog;
+            $previous_timelog = $current_timelog;
         }
-        return $daysWithLogs;
+        return $days_with_logs;
     }
 }


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (7.2 for current, 7.0 for legacy).
- [x] Tests are passing.
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] PHPCS has reported no errors to my changes.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.

<!-- Add a short description. -->
## Description
Feature is implemented to stop timelog entries from a single day being divded across 2 pages - displaying inaccurate information about the total hours worked on a given date.

<!-- List your changes as a dot point list. -->
## Changelog
- Timelogs are now displayed in groups of 10 days
- Timelog displays can no longer be split across pages

<!-- Add any important refs or issues numbers. -->
refs: 1221
issues:

<!-- Add any other information that might be relevant. -->
## Other Information
