### PR TITLE
Hotfix/datepicker z index

### DIFF
--- a/system/modules/timelog/actions/index.php
+++ b/system/modules/timelog/actions/index.php
@@ -5,22 +5,27 @@ define('TIMELOG_DEFAULT_PAGE_SIZE', 20);
 
 function index_GET(Web $w) {
     $page = $w->request("p", TIMELOG_DEFAULT_PAGE);
-    $pagesize = $w->request("ps", TIMELOG_DEFAULT_PAGE_SIZE);
+    $page_size = $w->request("ps", TIMELOG_DEFAULT_PAGE_SIZE);
     
-	// Get paged timelogs
-    $timelog = $w->Timelog->getTimelogsForUser($w->Auth->user(), false, $page, $pagesize);
-    $totalresults = $w->Timelog->countTotalTimelogsForUser($w->Auth->user(), false);
+    //Get days in their 10 day groupings
+    $days_with_timelogs = TimelogService::getInstance($w)->daysForTimelogs($w->Auth->user());
+    //Get the day group corrosponding to the current page
+    $page_bracket = $days_with_timelogs[$page - 1];
+    //Get timelogs to display that belong to the corrosponding 10 days
+    $timelog = TimelogService::getInstance($w)->getTimelogsForUser($w->Auth->user(), false, $page_bracket[count($page_bracket) - 1], $page_bracket[0]);
 
-    $w->ctx('pagination', Html::pagination($page, (ceil($totalresults / $pagesize)), $pagesize, $totalresults, '/timelog'));
+    $total_results = TimelogService::getInstance($w)->countTotalTimelogsForUser($w->Auth->user(), false);
+
+    $w->ctx('pagination', Html::pagination($page, (count($days_with_timelogs)), $page_size, ($total_results), '/timelog'));
     
-    $time_entry_objects = array();
-	
+    $time_entry_objects = [];
+
     if (!empty($timelog)) {
-        foreach($timelog as $time_entry) {
+        foreach ($timelog as $time_entry) {
             
             $entry_date = date('d/m', $time_entry->dt_start);
             if (empty($time_entry_objects[$entry_date])) {
-                $time_entry_objects[$entry_date] = array('entries' => array(), "total" => 0);
+                $time_entry_objects[$entry_date] = ['entries' => [], "total" => 0];
             }
 
             $time_entry_objects[$entry_date]['total'] += $time_entry->getDuration();

--- a/system/modules/timelog/models/TimelogService.php
+++ b/system/modules/timelog/models/TimelogService.php
@@ -8,80 +8,91 @@
 class TimelogService extends DbService {
     private $_trackObject = null;
 
-	/**
-	 * Returns all time logs for a given user
-	 *
-	 * @param User $user
-	 * @param boolean $includeDeleted
-	 * @return Timelog
-	 */
-    public function getTimelogsForUser(User $user = null, $includeDeleted = false, $page = 1, $page_size = 20) {
+    /**
+     * Returns all time logs for a given user
+     *
+     * @param User $user
+     * @param boolean $includeDeleted
+     * @return Timelog
+     */
+    public function getTimelogsForUser(User $user = null, $include_deleted = false, $time_start = null, $time_end = null) {
+       
         if ($user === null) {
             $user = $this->w->Auth->user();
         }
 
         $where = ['user_id' => $user->id];
-        if (!$includeDeleted) {
+        if (!$include_deleted) {
             $where['is_deleted'] = 0;
         }
 
-        return $this->getObjects("Timelog", $where, false, true, "dt_start DESC", ($page - 1) * $page_size, $page_size);
+        if (!empty($time_start) && !empty($time_end)) {
+            $bracket_start = $time_start->dt_start;
+            $start_condition = date('Y-m-d H:i:s', $bracket_start);
+            $where['dt_start >= ?'] = $start_condition;
+            
+            $bracket_end = $time_end->dt_end;
+            $end_condition = date('Y-m-d H:i:s', $bracket_end);
+            $where['dt_start <= ?'] = $end_condition;
+        }
+
+        return $this->getObjects("Timelog", $where, false, true, "dt_start DESC", null, 100);
     }
 
-	public function countTotalTimelogsForUser(User $user = null, $includeDeleted = false) {
+    public function countTotalTimelogsForUser(User $user = null, $include_deleted = false) {
         if ($user === null) {
             $user = $this->w->Auth->user();
         }
 
         $where = ['user_id' => $user->id];
-        if (!$includeDeleted) {
+        if (!$include_deleted) {
             $where['is_deleted'] = 0;
         }
 
         return $this->db->get("timelog")->where($where)->count();
     }
 
-	public function getTimelogsForObject($object) {
-		if (!empty($object->id)) {
-			return $this->getObjects("Timelog", ["object_class" => get_class($object), "object_id" => $object->id, "is_deleted" => 0]);
-		}
-	}
+    public function getTimelogsForObject($object) {
+        if (!empty($object->id)) {
+            return $this->getObjects("Timelog", ["object_class" => get_class($object), "object_id" => $object->id, "is_deleted" => 0]);
+        }
+    }
 
-	/**
-	 * Returns number of timelogs for a given object
-	 *
-	 * @param DbObject $object
-	 * @return int
-	 */
-	public function countTimelogsForObject($object) {
-		if (!empty($object->id)) {
-			return $this->w->db->get('timelog')->where("object_class", get_class($object))->where("object_id", $object->id)
-						->where('is_deleted', 0)->count();
-		}
-		return 0;
-	}
+    /**
+     * Returns number of timelogs for a given object
+     *
+     * @param DbObject $object
+     * @return int
+     */
+    public function countTimelogsForObject($object) {
+        if (!empty($object->id)) {
+            return $this->w->db->get('timelog')->where("object_class", get_class($object))->where("object_id", $object->id)
+                        ->where('is_deleted', 0)->count();
+        }
+        return 0;
+    }
 
-	public function getTimelogsForObjectByClassAndId($object_class, $object_id) {
-		if (!empty($object_class) || !empty($object_id)) {
-			return $this->getObjects("Timelog", ["object_class" => $object_class, "object_id" => $object_id, "is_deleted" => 0], false, true, "dt_start ASC");
-		}
-	}
+    public function getTimelogsForObjectByClassAndId($object_class, $object_id) {
+        if (!empty($object_class) || !empty($object_id)) {
+            return $this->getObjects("Timelog", ["object_class" => $object_class, "object_id" => $object_id, "is_deleted" => 0], false, true, "dt_start ASC");
+        }
+    }
 
-	public function countTimelogsForUserAndObject($user, $object) {
-		if (!empty($user) && !empty($object) && is_a($object, 'DbObject')) {
-			return $this->w->db->get('timelog')->where('user_id', $user->id)
-					->where("object_class", get_class($object))
-					->where("object_id", $object->id)
-					->where('is_deleted', 0)->count();
-		}
-		return 0;
-	}
+    public function countTimelogsForUserAndObject($user, $object) {
+        if (!empty($user) && !empty($object) && is_a($object, 'DbObject')) {
+            return $this->w->db->get('timelog')->where('user_id', $user->id)
+                    ->where("object_class", get_class($object))
+                    ->where("object_id", $object->id)
+                    ->where('is_deleted', 0)->count();
+        }
+        return 0;
+    }
 
-	/**
-	 * Returns all non deleted timelogs
-	 *
-	 * @return Array<Timelog>
-	 */
+    /**
+     * Returns all non deleted timelogs
+     *
+     * @return Array<Timelog>
+     */
     public function getTimelogs() {
         return $this->getObjects("Timelog", ["is_deleted" => 0]);
     }
@@ -95,7 +106,7 @@ class TimelogService extends DbService {
     }
 
     public function hasActiveLog() {
-		$timelog = $this->getActiveTimeLogForUser();
+        $timelog = $this->getActiveTimeLogForUser();
         return !empty($timelog);
     }
 
@@ -111,11 +122,11 @@ class TimelogService extends DbService {
         return $this->_trackObject;
     }
 
-	public function getTrackingObjectClass() {
-		if ($this->hasTrackingObject()) {
-			return get_class($this->_trackObject);
-		}
-	}
+    public function getTrackingObjectClass() {
+        if ($this->hasTrackingObject()) {
+            return get_class($this->_trackObject);
+        }
+    }
 
     public function getJSTrackingObject() {
         if ($this->hasTrackingObject()) {
@@ -139,21 +150,21 @@ class TimelogService extends DbService {
         //get a list of all active modules
         $objects = [];
         $modules = array_filter(Config::keys() ? : [], function($module) {
-			return Config::get("$module.active") === true;
-		});
+            return Config::get("$module.active") === true;
+        });
 
-		if (!empty($modules)) {
-			foreach ($modules as $key => $module) {
-				$timelog = Config::get("$module.timelog");
-				//check module config for timelog enabled objects
-				if ($timelog !== null && is_array($timelog)) {
-					foreach ($timelog as $value) {
-						$objects[$value] = $value;
-					}
-				}
+        if (!empty($modules)) {
+            foreach ($modules as $key => $module) {
+                $timelog = Config::get("$module.timelog");
+                //check module config for timelog enabled objects
+                if ($timelog !== null && is_array($timelog)) {
+                    foreach ($timelog as $value) {
+                        $objects[$value] = $value;
+                    }
+                }
 
-			}
-		}
+            }
+        }
         return $objects;
     }
 
@@ -164,14 +175,46 @@ class TimelogService extends DbService {
 
         $nav = $nav ? : array();
 
-        $trackingObject = $w->Timelog->getTrackingObject();
+        $tracking_object = $w->Timelog->getTrackingObject();
 
         if ($w->Auth->loggedIn()) {
             $w->menuLink("timelog/index", "Timelog Dashboard", $nav);
-            $w->menuBox("timelog/edit" . (!empty($trackingObject) && !empty($trackingObject->id) ? "?class=" . get_class($trackingObject) . "&id=" . $trackingObject->id : ''), "Add Timelog", $nav);
+            $w->menuBox("timelog/edit" . (!empty($tracking_object) && !empty($tracking_object->id) ? "?class=" . get_class($tracking_object) . "&id=" . $tracking_object->id : ''), "Add Timelog", $nav);
         }
 
         $w->ctx("navigation", $nav);
         return $nav;
+    }
+
+    //Returns an array of timelogs in groups of 10 days
+    public function daysForTimelogs($user) {
+        $timelogs = $this->timelog->getTimelogsForUser($user);
+        $previous_timelog = null;
+        $current_timelog = null;
+
+        $days_with_logs = [];
+        $i = 0;
+        $subset_count = -1;
+
+        foreach ($timelogs as $timelog) {
+            $current_timelog = $timelog;
+            if ($previous_timelog != null) {
+                $date = $current_timelog->dt_start;
+                $previous_date = $previous_timelog->dt_start;
+
+                $result = date('d', $date) === date('d', $previous_date);
+
+                if ($result == false) {
+                    if ($i % 10 == 0) {
+                        $subset_count += 1;
+                    }
+
+                    $days_with_logs[$subset_count][] = $timelog;
+                    $i += 1;
+                }
+            }
+            $previous_timelog = $current_timelog;
+        }
+        return $days_with_logs;
     }
 }

--- a/system/templates/css/datePicker.css
+++ b/system/templates/css/datePicker.css
@@ -154,3 +154,6 @@ div.dp-popup td.disabled {
 .ui-timepicker-div dl dt{ font-size: 0.9em; height: 25px; }
 .ui-timepicker-div dl dd{ font-size: 0.9em; margin: -25px 0 10px 65px; }
 .ui-timepicker-div td { font-size: 0.9em; }
+
+/* fix datepicker from being obscured by a task field */
+.ui-datepicker{z-index: 10 !important};


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (7.2 for current, 7.0 for legacy).
- [x] Tests are passing.
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] PHPCS has reported no errors to my changes.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.

<!-- Add a short description. -->
On the edit task page when the datepicker widget floats to the top it is obscured by other form elements. This fix forces the z index to be greater than the other form fields.

<!-- List your changes as a dot point list. -->
- Add single CSS rule to update datepicker z-index attribute

<!-- Add any important refs or issues numbers. -->
refs: 9630