### PR TITLE
feat: https protocol fixed when using Nginx

### DIFF
--- a/system/web.php
+++ b/system/web.php
@@ -154,11 +154,10 @@ class Web
         $sHttpXssl = $this->getRequestHeader('HTTP_X_FORWARDED_SSL');
 
         // if using IIS then value is "off" for non ssl requests
-        if ( (strtolower($sHttps) !== "off") || (strtolower($sHttpXproto) == "https") || (strtolower($sHttpXssl) == "on") )
-        {
+        if ((strtolower($sHttps) !== "off") || (strtolower($sHttpXproto) == "https") || (strtolower($sHttpXssl) == "on")) {
             return "https://";
         }
-        return "http://";              
+        return "http://";
     }
 
     private function getHostname()
@@ -166,10 +165,9 @@ class Web
         return $this->getRequestHeader('HTTP_HOST');
     }
 
-    private function getRequestHeader($header, $default='')
+    private function getRequestHeader($header, $default = '')
     {
-        if (array_key_exists($header, $_SERVER) && !empty($_SERVER[$header] ) )
-        {
+        if (array_key_exists($header, $_SERVER) && !empty($_SERVER[$header])) {
             return $_SERVER[$header];
         }
         return $default;


### PR DESCRIPTION
cmfive hosted with Nginx resulted in a http being used to post forms,
depsite SSL configured for Nginx.

The solution checks request header to determine if the schema type

refs: 9926

<!-- Have you made sure the following is correct? -->
## Checklist
- [X] I'm using the correct PHP Version (7.2 for current, 7.0 for legacy).
- [X] Tests are passing.
- [X] I've added comments to any new methods I've created or where else relevant.
- [x] PHPCS has reported no errors to my changes.
- [X] I've replaced magic method usage on DbService classes with the getInstance() static method.

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs: 9816

<!-- Add any other information that might be relevant. -->
## Other Information
