### PR TITLE
feat: tooltip capability added to multi-column form

### DIFF
--- a/system/html.php
+++ b/system/html.php
@@ -608,7 +608,11 @@ class Html
                     continue;
                 }
 
-                foreach ($row as $field) {
+                foreach ($row as $entry) {
+                    // Backwards compatibility - provide option to pass additional data
+                    $field = array_key_exists('field', $entry) ? $entry['field'] : $entry;
+                    $tooltip = array_key_exists('tooltip', $entry) ? $entry['tooltip'] : null;
+
                     // Check if the row is an object like an InputField
                     if (!is_array($field) && is_object($field)) {
                         if ((property_exists($field, "type") && $field->type !== "hidden") || !property_exists($field, "type")) {
@@ -641,6 +645,9 @@ class Html
                     // Add title field
                     if (!empty($title) && $type !== "hidden") {
                         $buffer .= "<label class='small-12 columns'>$title";
+                        if (!empty($tooltip)) {
+                            $buffer .= " <span data-tooltip aria-haspopup='true' class='has-tip fi-info' title='" . $tooltip . "'></span>";
+                        }
                     }
                     $buffer .= ($type !== "hidden" ? "<div>" : "");
 


### PR DESCRIPTION
The change is backwards compatible with existing API

<!-- Have you made sure the following is correct? -->
## Checklist
- [X] I'm using the correct PHP Version (7.2 for current, 7.0 for legacy).
- [X] Tests are passing.
- [X] I've added comments to any new methods I've created or where else relevant.
- [X] PHPCS has reported no errors to my changes.
- [X] I've replaced magic method usage on DbService classes with the getInstance() static method.

<!-- Add a short description. -->
This change provides support for multi-columns forms to add tooltips. API is backwards compatible
