### PR TITLE
feat: hide metadata button

### DIFF
--- a/system/modules/file/models/Attachment.php
+++ b/system/modules/file/models/Attachment.php
@@ -223,8 +223,8 @@ class Attachment extends DbObject
      */
     public function getFilePath(): string
     {
-        if (file_exists(ROOT_PATH . "/" . Attachment::CACHE_PATH . "/". Attachment::TEMP_PATH . "/" . FileService::getCacheRuntimePath() . "/" . $this->id . "/" . $this->dt_created . "/" . $this->filename)) {
-            return ROOT_PATH . "/" . Attachment::CACHE_PATH . "/". Attachment::TEMP_PATH . "/" . FileService::getCacheRuntimePath() . "/" . $this->id . "/" . $this->dt_created;
+        if (file_exists(ROOT_PATH . "/" . Attachment::CACHE_PATH . "/" . Attachment::TEMP_PATH . "/" . FileService::getCacheRuntimePath() . "/" . $this->id . "/" . $this->dt_created . "/" . $this->filename)) {
+            return ROOT_PATH . "/" . Attachment::CACHE_PATH . "/" . Attachment::TEMP_PATH . "/" . FileService::getCacheRuntimePath() . "/" . $this->id . "/" . $this->dt_created;
         }
 
         $path = dirname($this->fullpath);

--- a/system/modules/file/partials/templates/attachment_item.tpl.php
+++ b/system/modules/file/partials/templates/attachment_item.tpl.php
@@ -47,13 +47,15 @@
     <h2 id="firstModalTitle" style="font-weight: lighter; text-align: center; border-bottom: 1px solid #777;"><?php echo $attachment->title; ?></h2>
     <p style="text-align: center;"><?php echo $attachment->description; ?></p>
     <div class="row-fluid">
-        <div class="small-4 columns">
+        <div class="column small-12 medium-<?php echo $attachment->isImage() ? '4' : '6'; ?>">
             <a href="/file/atfile/<?php echo $attachment->id; ?>" target="_blank" class="button expand" onclick="$('#attachment_modal_<?php echo $attachment->id; ?>').foundation('reveal', 'close');">Open in new tab</a>
         </div>
-        <div class="small-4 columns">
-            <a href="/file-image/metadata/<?php echo $attachment->id; ?>" target="_blank" class="button expand" onclick="$('#attachment_modal_<?php echo $attachment->id; ?>').foundation('reveal', 'close');">View metadata</a>
-        </div>
-        <div class='small-4 columns'>
+        <?php if ($attachment->isImage()) { ?>
+            <div class="column small-12 medium-4">
+                <a href="/file-image/metadata/<?php echo $attachment->id; ?>" target="_blank" class="button expand" onclick="$('#attachment_modal_<?php echo $attachment->id; ?>').foundation('reveal', 'close');">View metadata</a>
+            </div>
+        <?php } ?>
+        <div class="column small-12 medium-<?php echo $attachment->isImage() ? '4' : '6'; ?>">
             <a class="button expand secondary" onclick="$('#attachment_modal_<?php echo $attachment->id; ?>').foundation('reveal', 'close');" aria-label="Close">Close</a>
         </div>
     </div>


### PR DESCRIPTION
## Checklist
- [X] I'm using the correct PHP Version (7.2 for current, 7.0 for legacy).
- [X] Tests are passing.
- [X] I've added comments to any new methods I've created or where else relevant.
- [X] PHPCS has reported no errors to my changes.
- [X] I've replaced magic method usage on DbService classes with the getInstance() static method.

## Changelog
- Updated "View Metadata" button to not render when the attachment isn't an image.

refs: 9915