### PR TITLE
fix: cannot remove dbobject restriction

### DIFF
--- a/system/modules/admin/actions/ajaxAddComment.php
+++ b/system/modules/admin/actions/ajaxAddComment.php
@@ -10,7 +10,7 @@ function ajaxAddComment_POST(Web $w)
         return;
     }
 
-    $user = $w->Auth->user();
+    $user = AuthService::getInstance($w)->user();
     if ($request_data->is_restricted && !$user->hasRole("restrict")) {
         $w->out((new AxiosResponse())->setErrorResponse(null, ["error_message" => "User not authorised to restrict objects"]));
         return;
@@ -18,7 +18,7 @@ function ajaxAddComment_POST(Web $w)
 
     $comment = null;
     if (!empty($request_data->comment_id)) {
-        $comment = $w->Comment->getComment($request_data->comment_id);
+        $comment = CommentService::getInstance($w)->getComment($request_data->comment_id);
     }
 
     $is_new = false;
@@ -43,11 +43,12 @@ function ajaxAddComment_POST(Web $w)
     $comment->creator_id = $request_data->new_owner->id;
     $comment->insertOrUpdate();
 
+
     if ($request_data->is_restricted) {
         RestrictableService::getInstance($w)->setOwner($comment, $request_data->new_owner->id);
 
         foreach (!empty($request_data->viewers) ? $request_data->viewers : [] as $viewer) {
-            if ($viewer->id == $w->Auth->user()->id) {
+            if ($viewer->id == AuthService::getInstance($w)->user()->id) {
                 continue;
             }
 
@@ -55,10 +56,12 @@ function ajaxAddComment_POST(Web $w)
                 RestrictableService::getInstance($w)->addViewer($comment, $viewer->id);
             }
         }
+    } elseif (!$request_data->is_restricted && RestrictableService::getInstance($w)->isRestricted($comment)) {
+        RestrictableService::getInstance($w)->unrestrict($comment);
     }
 
     if ($top_object_table_name === "comment") {
-        $top_object = $w->Comment->getComment($top_object_id)->getParentObject();
+        $top_object = CommentService::getInstance($w)->getComment($top_object_id)->getParentObject();
         $top_object_table_name = $top_object->getDbTableName();
         $top_object_id = $top_object->id;
     }

--- a/system/modules/admin/actions/ajaxAddComment.php
+++ b/system/modules/admin/actions/ajaxAddComment.php
@@ -28,7 +28,7 @@ function ajaxAddComment_POST(Web $w)
         $comment->is_internal = $request_data->is_internal_only;
         $is_new = true;
     } else {
-        $current_viewers = $w->Restrictable->getViewerLinks($comment);
+        $current_viewers = RestrictableService::getInstance($w)->getViewerLinks($comment);
         foreach (empty($current_viewers) ? [] : $current_viewers as $current_viewer) {
             $current_viewer->delete();
         }
@@ -44,7 +44,7 @@ function ajaxAddComment_POST(Web $w)
     $comment->insertOrUpdate();
 
     if ($request_data->is_restricted) {
-        $w->Restrictable->setOwner($comment, $request_data->new_owner->id);
+        RestrictableService::getInstance($w)->setOwner($comment, $request_data->new_owner->id);
 
         foreach (!empty($request_data->viewers) ? $request_data->viewers : [] as $viewer) {
             if ($viewer->id == $w->Auth->user()->id) {
@@ -52,7 +52,7 @@ function ajaxAddComment_POST(Web $w)
             }
 
             if ($viewer->can_view) {
-                $w->Restrictable->addViewer($comment, $viewer->id);
+                RestrictableService::getInstance($w)->addViewer($comment, $viewer->id);
             }
         }
     }

--- a/system/modules/main/models/RestrictableService.php
+++ b/system/modules/main/models/RestrictableService.php
@@ -1,118 +1,135 @@
 <?php
 
-class RestrictableService extends DbService {
+class RestrictableService extends DbService
+{
 
-	public function setOwner($object, $user_id) {
-		if (!property_exists($object, "_restrictable")) {
-			return false;
-		}
+    public function setOwner($object, $user_id)
+    {
+        if (!property_exists($object, "_restrictable")) {
+            return false;
+        }
 
-		$link = $this->w->Main->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "type" => "owner"]);
-		if (empty($link)) {
-			$link = new RestrictedObjectUserLink($this->w);
-		}
+        $link = MainService::getInstance($this->w)->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "type" => "owner"]);
+        if (empty($link)) {
+            $link = new RestrictedObjectUserLink($this->w);
+        }
 
-		$link->object_class = get_class($object);
-		$link->object_id = $object->id;
-		$link->user_id = $user_id;
-		$link->type = "owner";
+        $link->object_class = get_class($object);
+        $link->object_id = $object->id;
+        $link->user_id = $user_id;
+        $link->type = "owner";
 
-		if ($link->insertOrUpdate()) {
-			return true;
-		}
-		return false;
-	}
+        if ($link->insertOrUpdate()) {
+            return true;
+        }
+        return false;
+    }
 
-	public function addViewer($object, $user_id) {
-		if (!property_exists($object, "_restrictable")) {
-			return false;
-		}
+    public function addViewer($object, $user_id)
+    {
+        if (!property_exists($object, "_restrictable")) {
+            return false;
+        }
 
-		$logged_in_user_id = $this->w->Auth->user()->id;
-		$owner_link = $this->w->Main->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "user_id" => $logged_in_user_id, "type" => "owner"]);
+        $logged_in_user_id = AuthService::getInstance($this->w)->user()->id;
+        $owner_link = MainService::getInstance($this->w)->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "user_id" => $logged_in_user_id, "type" => "owner"]);
 
-		if (empty($owner_link) || $logged_in_user_id !== $owner_link->user_id) {
-			return false;
-		}
+        if (empty($owner_link) || $logged_in_user_id !== $owner_link->user_id) {
+            return false;
+        }
 
-		$link = new RestrictedObjectUserLink($this->w);
-		$link->object_class = get_class($object);
-		$link->object_id = $object->id;
-		$link->user_id = $user_id;
-		$link->type = "viewer";
+        $link = new RestrictedObjectUserLink($this->w);
+        $link->object_class = get_class($object);
+        $link->object_id = $object->id;
+        $link->user_id = $user_id;
+        $link->type = "viewer";
 
-		if ($link->insert()) {
-			return true;
-		}
-		return false;
-	}
+        if ($link->insert()) {
+            return true;
+        }
+        return false;
+    }
 
-	public function removeViewer($object, $user_id) {
-		if (!property_exists($object, "_restrictable")) {
-			return false;
-		}
+    public function removeViewer($object, $user_id)
+    {
+        if (!property_exists($object, "_restrictable")) {
+            return false;
+        }
 
-		$logged_in_user_id = $this->w->Auth->user()->id;
-		$owner_link = $this->w->Main->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "user_id" => $logged_in_user_id, "type" => "owner"]);
+        $logged_in_user_id = AuthService::getInstance($this->w)->user()->id;
+        $owner_link = MainService::getInstance($this->w)->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "user_id" => $logged_in_user_id, "type" => "owner"]);
 
-		if ($logged_in_user_id !== $owner_link->user_id) {
-			return false;
-		}
+        if ($logged_in_user_id !== $owner_link->user_id) {
+            return false;
+        }
 
-		$link = $this->w->Main->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "user_id" => $user_id, "type" => "viewer"]);
-		if (!empty($link) && $link->delete()) {
-			return true;
-		}
-		return false;
-	}
+        $link = MainService::getInstance($this->w)->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "user_id" => $user_id, "type" => "viewer"]);
+        if (!empty($link) && $link->delete()) {
+            return true;
+        }
+        return false;
+    }
 
-	public function getOwner($object) {
-		if (!property_exists($object, "_restrictable")) {
-			return false;
-		}
+    public function getOwner($object)
+    {
+        if (!property_exists($object, "_restrictable")) {
+            return false;
+        }
 
-		$link = $this->w->Main->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "type" => "owner"]);
-		if (empty($link)) {
-			return null;
-		}
+        $link = MainService::getInstance($this->w)->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "type" => "owner"]);
+        if (empty($link)) {
+            return null;
+        }
 
-		return $this->w->Auth->getObject("User", $link->user_id);
-	}
+        return AuthService::getInstance($this->w)->getObject("User", $link->user_id);
+    }
 
-	public function getViewers($object) {
-		if (!property_exists($object, "_restrictable")) {
-			return false;
-		}
+    public function getViewers($object)
+    {
+        if (!property_exists($object, "_restrictable")) {
+            return false;
+        }
 
-		$links = $this->w->Main->getObjects("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "type" => "viewer"]);
-		if (empty($links)) {
-			return null;
-		}
+        $links = MainService::getInstance($this->w)->getObjects("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "type" => "viewer"]);
+        if (empty($links)) {
+            return null;
+        }
 
-		$viewers = [];
-		foreach ($links as $link) {
-			$viewer = $this->w->Auth->getUser($link->user_id);
-			if (!empty($viewer)) {
-				$viewers[] = $viewer;
-			}
-		}
+        $viewers = [];
+        foreach ($links as $link) {
+            $viewer = AuthService::getInstance($this->w)->getUser($link->user_id);
+            if (!empty($viewer)) {
+                $viewers[] = $viewer;
+            }
+        }
 
-		return $viewers;
-	}
+        return $viewers;
+    }
 
-	public function getOwnerLink($object) {
-		if (!property_exists($object, "_restrictable")) {
-			return false;
-		}
+    public function getOwnerLink($object)
+    {
+        if (!property_exists($object, "_restrictable")) {
+            return false;
+        }
 
-		return $this->w->Main->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "type" => "owner"]);
-	}
+        return MainService::getInstance($this->w)->getObject("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "type" => "owner"]);
+    }
 
-	public function getViewerLinks($object) {
-		if (!property_exists($object, "_restrictable")) {
-			return false;
-		}
+    public function getViewerLinks($object)
+    {
+        if (!property_exists($object, "_restrictable")) {
+            return false;
+        }
 
-		return $this->w->Main->getObjects("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "type" => "viewer"]);
-	}
+        return MainService::getInstance($this->w)->getObjects("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "type" => "viewer"]);
+    }
+
+    public function isRestricted(DbObject $object): bool
+    {
+        if (!property_exists($object, "_restrictable")) {
+            return false;
+        }
+
+        return $this->_db->get("restricted_object_user_link")->where("object_id", $object->id, "object_class")->where("object_class", $object->getDbTableName())->count() > 0;
+    }
 }

--- a/system/modules/main/models/RestrictableService.php
+++ b/system/modules/main/models/RestrictableService.php
@@ -151,7 +151,7 @@ class RestrictableService extends DbService
             return;
         }
 
-        $links = $this->getObjects("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object)]);
+        $links = $this->getObjects("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => $object->getDbTableName()]);
         foreach ($links as $link) {
             $link->delete();
         }

--- a/system/modules/main/models/RestrictableService.php
+++ b/system/modules/main/models/RestrictableService.php
@@ -124,6 +124,12 @@ class RestrictableService extends DbService
         return MainService::getInstance($this->w)->getObjects("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object), "type" => "viewer"]);
     }
 
+    /**
+     * Will ckeck if a DbObject is restricted.
+     *
+     * @param DbObject $object
+     * @return boolean
+     */
     public function isRestricted(DbObject $object): bool
     {
         if (!property_exists($object, "_restrictable")) {
@@ -131,5 +137,23 @@ class RestrictableService extends DbService
         }
 
         return $this->_db->get("restricted_object_user_link")->where("object_id", $object->id, "object_class")->where("object_class", $object->getDbTableName())->count() > 0;
+    }
+
+    /**
+     * Removes restrictions from a DbObject.
+     *
+     * @param DbObject $object
+     * @return void
+     */
+    public function unrestrict(DbObject $object): void
+    {
+        if (!property_exists($object, "_restrictable")) {
+            return;
+        }
+
+        $links = $this->getObjects("RestrictedObjectUserLink", ["object_id" => $object->id, "object_class" => get_class($object)]);
+        foreach ($links as $link) {
+            $link->delete();
+        }
     }
 }


### PR DESCRIPTION
## Checklist
- [X] I'm using the correct PHP Version (7.2 for current, 7.0 for legacy).
- [X] Tests are passing.
- [X] I've added comments to any new methods I've created or where else relevant.
- [X] PHPCS has reported no errors to my changes.
- [X] I've replaced magic method usage on DbService classes with the getInstance() static method.

## Description
Fixed bug stopping DbObjects from being able to have their restriction removed.

## Changelog
- Added RestrictableService::isRestricted method.
- Added RestrictableService::unrestrict method.
- Fixed bug causing DbObjects not being able to have their restriction removed.

refs: 9781