### PR TITLE
fix: hook exception handling

### DIFF
--- a/system/modules/task/task.hooks.php
+++ b/system/modules/task/task.hooks.php
@@ -135,7 +135,7 @@ function task_task_subscriber_notification(Web $w, $params)
 {
     $task = TaskService::getInstance($w)->getTask($params["task_id"]);
     $user = AuthService::getInstance($w)->getUser($params["user_id"]);
-    
+
     TaskService::getInstance($w)->sendSubscribeNotificationForTask($task, $user);
 }
 
@@ -335,8 +335,8 @@ function task_core_dbobject_after_update_TaskGroup(Web $w, $object)
             if ($task->isUserSubscribed($user->id) && !$task->canView($user)) {
                 //If so, remove subscription
                 TaskService::getInstance($w)->getSubscriberForUserAndTask($user->id, $task->id)->delete();
-            }    
-        } 
+            }
+        }
     }
 
 


### PR DESCRIPTION
## Checklist
- [X] I'm using the correct PHP Version (7.2 for current, 7.0 for legacy).
- [X] Tests are passing.
- [X] I've added comments to any new methods I've created or where else relevant.
- [X] PHPCS has reported no errors to my changes.
- [X] I've replaced magic method usage on DbService classes with the getInstance() static method.

## Description
Currently, any hooks called that throw an exception will stop the page from rendering at all. Exceptions from hooks should be caught and logged so the rest of the page can still render correctly.

## Changelog
- Wrapped hook call in a try-catch to handle exceptions caused by the hook function.

refs: 8186