### PR TITLE
fix: timelog fix

### DIFF
--- a/system/modules/timelog/actions/index.php
+++ b/system/modules/timelog/actions/index.php
@@ -3,33 +3,28 @@
 define('TIMELOG_DEFAULT_PAGE', 1);
 define('TIMELOG_DEFAULT_PAGE_SIZE', 20);
 
-function index_GET(Web $w) {
+function index_GET(Web $w)
+{
     $page = $w->request("p", TIMELOG_DEFAULT_PAGE);
-    $page_size = $w->request("ps", TIMELOG_DEFAULT_PAGE_SIZE);
-    
-    //Get days in their 10 day groupings
-    $days_with_timelogs = TimelogService::getInstance($w)->daysForTimelogs($w->Auth->user());
-    //Get the day group corrosponding to the current page
-    $page_bracket = $days_with_timelogs[$page - 1];
-    //Get timelogs to display that belong to the corrosponding 10 days
-    $timelog = TimelogService::getInstance($w)->getTimelogsForUser($w->Auth->user(), false, $page_bracket[count($page_bracket) - 1], $page_bracket[0]);
+    $pagesize = $w->request("ps", TIMELOG_DEFAULT_PAGE_SIZE);
 
-    $total_results = TimelogService::getInstance($w)->countTotalTimelogsForUser($w->Auth->user(), false);
+    // Get paged timelogs
+    $timelog = $w->Timelog->getTimelogsForUser($w->Auth->user(), false, $page, $pagesize);
+    $totalresults = $w->Timelog->countTotalTimelogsForUser($w->Auth->user(), false);
 
-    $w->ctx('pagination', Html::pagination($page, (count($days_with_timelogs)), $page_size, ($total_results), '/timelog'));
-    
+    $w->ctx('pagination', Html::pagination($page, (ceil($totalresults / $pagesize)), $pagesize, $totalresults, '/timelog'));
+
     $time_entry_objects = [];
 
     if (!empty($timelog)) {
         foreach ($timelog as $time_entry) {
-            
             $entry_date = date('d/m', $time_entry->dt_start);
             if (empty($time_entry_objects[$entry_date])) {
                 $time_entry_objects[$entry_date] = ['entries' => [], "total" => 0];
             }
 
             $time_entry_objects[$entry_date]['total'] += $time_entry->getDuration();
-            $time_entry_objects[$entry_date]['entries'][] = $time_entry; 
+            $time_entry_objects[$entry_date]['entries'][] = $time_entry;
         }
     }
 

--- a/system/modules/timelog/models/TimelogService.php
+++ b/system/modules/timelog/models/TimelogService.php
@@ -5,7 +5,8 @@
  *
  * @author Adam Buckley <adam@2pisoftware.com>
  */
-class TimelogService extends DbService {
+class TimelogService extends DbService
+{
     private $_trackObject = null;
 
     /**
@@ -15,44 +16,36 @@ class TimelogService extends DbService {
      * @param boolean $includeDeleted
      * @return Timelog
      */
-    public function getTimelogsForUser(User $user = null, $include_deleted = false, $time_start = null, $time_end = null) {
-       
+    public function getTimelogsForUser(User $user = null, $includeDeleted = false, $page = 1, $page_size = 20)
+    {
         if ($user === null) {
             $user = $this->w->Auth->user();
         }
 
         $where = ['user_id' => $user->id];
-        if (!$include_deleted) {
+        if (!$includeDeleted) {
             $where['is_deleted'] = 0;
         }
 
-        if (!empty($time_start) && !empty($time_end)) {
-            $bracket_start = $time_start->dt_start;
-            $start_condition = date('Y-m-d H:i:s', $bracket_start);
-            $where['dt_start >= ?'] = $start_condition;
-            
-            $bracket_end = $time_end->dt_end;
-            $end_condition = date('Y-m-d H:i:s', $bracket_end);
-            $where['dt_start <= ?'] = $end_condition;
-        }
-
-        return $this->getObjects("Timelog", $where, false, true, "dt_start DESC", null, 100);
+        return $this->getObjects("Timelog", $where, false, true, "dt_start DESC", ($page - 1) * $page_size, $page_size);
     }
 
-    public function countTotalTimelogsForUser(User $user = null, $include_deleted = false) {
+    public function countTotalTimelogsForUser(User $user = null, $includeDeleted = false)
+    {
         if ($user === null) {
             $user = $this->w->Auth->user();
         }
 
         $where = ['user_id' => $user->id];
-        if (!$include_deleted) {
+        if (!$includeDeleted) {
             $where['is_deleted'] = 0;
         }
 
         return $this->db->get("timelog")->where($where)->count();
     }
 
-    public function getTimelogsForObject($object) {
+    public function getTimelogsForObject($object)
+    {
         if (!empty($object->id)) {
             return $this->getObjects("Timelog", ["object_class" => get_class($object), "object_id" => $object->id, "is_deleted" => 0]);
         }
@@ -64,26 +57,29 @@ class TimelogService extends DbService {
      * @param DbObject $object
      * @return int
      */
-    public function countTimelogsForObject($object) {
+    public function countTimelogsForObject($object)
+    {
         if (!empty($object->id)) {
             return $this->w->db->get('timelog')->where("object_class", get_class($object))->where("object_id", $object->id)
-                        ->where('is_deleted', 0)->count();
+                ->where('is_deleted', 0)->count();
         }
         return 0;
     }
 
-    public function getTimelogsForObjectByClassAndId($object_class, $object_id) {
+    public function getTimelogsForObjectByClassAndId($object_class, $object_id)
+    {
         if (!empty($object_class) || !empty($object_id)) {
             return $this->getObjects("Timelog", ["object_class" => $object_class, "object_id" => $object_id, "is_deleted" => 0], false, true, "dt_start ASC");
         }
     }
 
-    public function countTimelogsForUserAndObject($user, $object) {
+    public function countTimelogsForUserAndObject($user, $object)
+    {
         if (!empty($user) && !empty($object) && is_a($object, 'DbObject')) {
             return $this->w->db->get('timelog')->where('user_id', $user->id)
-                    ->where("object_class", get_class($object))
-                    ->where("object_id", $object->id)
-                    ->where('is_deleted', 0)->count();
+                ->where("object_class", get_class($object))
+                ->where("object_id", $object->id)
+                ->where('is_deleted', 0)->count();
         }
         return 0;
     }
@@ -93,42 +89,51 @@ class TimelogService extends DbService {
      *
      * @return Array<Timelog>
      */
-    public function getTimelogs() {
+    public function getTimelogs()
+    {
         return $this->getObjects("Timelog", ["is_deleted" => 0]);
     }
 
-    public function getTimelog($id) {
+    public function getTimelog($id)
+    {
         return $this->getObject("Timelog", $id);
     }
 
-    public function getActiveTimeLogForUser() {
+    public function getActiveTimeLogForUser()
+    {
         return $this->getObject("Timelog", ["is_deleted" => 0, "dt_end" => null, "user_id" => $this->w->Auth->user()->id]);
     }
 
-    public function hasActiveLog() {
+    public function hasActiveLog()
+    {
         $timelog = $this->getActiveTimeLogForUser();
         return !empty($timelog);
     }
 
-    public function hasTrackingObject() {
+    public function hasTrackingObject()
+    {
         return !empty($this->_trackObject);
     }
 
-    public function registerTrackingObject($object) {
+    public function registerTrackingObject($object)
+    {
         $this->_trackObject = $object;
     }
 
-    public function getTrackingObject() {
+    public function getTrackingObject()
+    {
         return $this->_trackObject;
     }
 
-    public function getTrackingObjectClass() {
+    public function getTrackingObjectClass()
+    {
         if ($this->hasTrackingObject()) {
             return get_class($this->_trackObject);
         }
     }
 
-    public function getJSTrackingObject() {
+    public function getJSTrackingObject()
+    {
         if ($this->hasTrackingObject()) {
             $class = new stdClass();
             $class->class = get_class($this->_trackObject);
@@ -137,8 +142,9 @@ class TimelogService extends DbService {
         }
     }
 
-    public function shouldShowTimer() {
-        // Check if tracking object set or existing timelog is running        
+    public function shouldShowTimer()
+    {
+        // Check if tracking object set or existing timelog is running
         return ((!empty(AuthService::getInstance($this->w)->user())) && AuthService::getInstance($this->w)->user()->hasRole("timelog_user") && ($this->hasTrackingObject() || $this->hasActiveLog()));
     }
 
@@ -146,10 +152,11 @@ class TimelogService extends DbService {
      * returns a list of objects to which you can attach timelogs
      * @return type array
      */
-    public function getLoggableObjects() {
+    public function getLoggableObjects()
+    {
         //get a list of all active modules
         $objects = [];
-        $modules = array_filter(Config::keys() ? : [], function($module) {
+        $modules = array_filter(Config::keys() ?: [], function ($module) {
             return Config::get("$module.active") === true;
         });
 
@@ -162,59 +169,27 @@ class TimelogService extends DbService {
                         $objects[$value] = $value;
                     }
                 }
-
             }
         }
         return $objects;
     }
 
-    public function navigation(Web $w, $title = null, $nav = null) {
+    public function navigation(Web $w, $title = null, $nav = null)
+    {
         if ($title) {
             $w->ctx("title", $title);
         }
 
-        $nav = $nav ? : array();
+        $nav = $nav ?: [];
 
-        $tracking_object = $w->Timelog->getTrackingObject();
+        $trackingObject = $w->Timelog->getTrackingObject();
 
         if ($w->Auth->loggedIn()) {
             $w->menuLink("timelog/index", "Timelog Dashboard", $nav);
-            $w->menuBox("timelog/edit" . (!empty($tracking_object) && !empty($tracking_object->id) ? "?class=" . get_class($tracking_object) . "&id=" . $tracking_object->id : ''), "Add Timelog", $nav);
+            $w->menuBox("timelog/edit" . (!empty($trackingObject) && !empty($trackingObject->id) ? "?class=" . get_class($trackingObject) . "&id=" . $trackingObject->id : ''), "Add Timelog", $nav);
         }
 
         $w->ctx("navigation", $nav);
         return $nav;
-    }
-
-    //Returns an array of timelogs in groups of 10 days
-    public function daysForTimelogs($user) {
-        $timelogs = $this->timelog->getTimelogsForUser($user);
-        $previous_timelog = null;
-        $current_timelog = null;
-
-        $days_with_logs = [];
-        $i = 0;
-        $subset_count = -1;
-
-        foreach ($timelogs as $timelog) {
-            $current_timelog = $timelog;
-            if ($previous_timelog != null) {
-                $date = $current_timelog->dt_start;
-                $previous_date = $previous_timelog->dt_start;
-
-                $result = date('d', $date) === date('d', $previous_date);
-
-                if ($result == false) {
-                    if ($i % 10 == 0) {
-                        $subset_count += 1;
-                    }
-
-                    $days_with_logs[$subset_count][] = $timelog;
-                    $i += 1;
-                }
-            }
-            $previous_timelog = $current_timelog;
-        }
-        return $days_with_logs;
     }
 }


### PR DESCRIPTION
## Checklist
- [X] I'm using the correct PHP Version (7.2 for current, 7.0 for legacy).
- [X] Tests are passing.
- [X] I've added comments to any new methods I've created or where else relevant.
- [X] PHPCS has reported no errors to my changes.
- [X] I've replaced magic method usage on DbService classes with the getInstance() static method.

## Description
The recent change to how Timelogs were displayed, had a bug where sometimes it wasn't showing two most recent days of Timelogs. Also, it made breaking changes to existing methods. I've reverted the changes to fix the bug and then we can possibly look into this feature in the future.

## Changelog
- Reverted back to the old way of displaying Timelogs.
- File formatting.