### PR TITLE
fix: prevent ratcheting of dates

### DIFF
--- a/system/classes/DbPDO.php
+++ b/system/classes/DbPDO.php
@@ -43,8 +43,9 @@ class DbPDO extends PDO
                 $url = "{$config['driver']}:host={$config['hostname']};dbname={$config['database']}{$port}";
         }
 
+        $timezone = date("e");
         $options = [
-            PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8mb4'",
+            PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8mb4', time_zone='".$timezone."'",
         ];
 
         if (!empty($config['ssl_cert_path'])) {

--- a/system/classes/DbPDO.php
+++ b/system/classes/DbPDO.php
@@ -43,9 +43,8 @@ class DbPDO extends PDO
                 $url = "{$config['driver']}:host={$config['hostname']};dbname={$config['database']}{$port}";
         }
 
-        $timezone = date("e");
         $options = [
-            PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8mb4', time_zone='".$timezone."'",
+            PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES 'utf8mb4', time_zone='" . date("e") . "'",
         ];
 
         if (!empty($config['ssl_cert_path'])) {

--- a/system/modules/main/tests/unit/DateTimeVsTimeZone.php
+++ b/system/modules/main/tests/unit/DateTimeVsTimeZone.php
@@ -1,0 +1,41 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class DateTimeVsTimeZone extends TestCase //\Codeception\Test\Unit
+{
+    public function testTimeZoneRatchet()
+    {
+        require_once("system/web.php");
+        require_once("system/classes/Config.php");
+
+        $w = new Web();  
+        
+        $timezone = Config::get('system.timezone');
+        if (empty($timezone)) {
+            $timezone = 'UTC';
+        }
+        date_default_timezone_set($timezone);
+
+        $w->initDB();
+
+        $creation = new Contact($w);
+        $creation->firstname = "initForDtTest";
+        $creation->insert();
+
+        $created = authService::getInstance($w)->getObject("contact",['firstname' => "initForDtTest"]);
+        $stamp = $created->dt_created;
+
+        for ($i = 0; $i < 20; $i++) {
+            $created = authService::getInstance($w)->getObject("contact",['firstname' => "initForDtTest"]);
+            $created->firstname = "looped_" . $i;
+            $created->update();
+        }
+
+        $flipped = $created->dt_created;
+        $created->delete();
+
+        $this->assertSame($stamp, $flipped);
+        $this->assertNotNull($stamp);
+    }
+}


### PR DESCRIPTION
Resolves peculiar observation where cmfive
and rds DB are in different TZ:
PDO internal cast of DB type to PHP type promotes TZ
whereas mySql asserts datetime is TZ agnostic
Resolved by informing PDO of correct cmfive host TZ

refs:
issues: observed problem on EMM proof

<!-- Have you made sure the following is correct? -->
## Checklist
- [Y] I'm using the correct PHP Version (7.2 for current, 7.0 for legacy).
- [Y] Tests are passing - unit test created for this hotfix
- [Y] I've added comments to any new methods I've created or where else relevant.
- [Y] PHPCS has reported no errors to my changes.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.

<!-- Add a short description. -->
## Simplify/tidy dbobject to clarify timezone interaction with dbpdo, and modify dbpdo connection

<!-- List your changes as a dot point list. -->
## Changelog
DbObject insert&update conformed to same conversion method
DbPDO has timezone param. added to connection
UnitTest applied to effects on dt_created of repeated insert/update

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information
Hotfix requirement revealed by cmfive host on EasternTime working into RDS on UTC
Hotfix retested for host on EasternTime and MySQL service on EasternTime