### PR TITLE
fix: deprecate 'array offset' style of string ref

### DIFF
--- a/system/html.php
+++ b/system/html.php
@@ -359,7 +359,7 @@ class Html
             $readonly = "";
 
             // handle disabled fields
-            if ($name !== null && $name[0] == '-') {
+            if (substr($name, 0, 1) == '-') {
                 $name = substr($name, 1);
                 $readonly = " readonly='true' ";
             }
@@ -652,7 +652,7 @@ class Html
                     $buffer .= ($type !== "hidden" ? "<div>" : "");
 
                     // handle disabled fields
-                    if ($name[0] == '-') {
+                    if (substr($name, 0, 1) == '-') {
                         $name = substr($name, 1);
                         $readonly = " readonly='true' ";
                     }
@@ -1322,7 +1322,7 @@ class Html
             }
 
             // handle disabled fields
-            if ($name[0] == '-') {
+            if (substr($name, 0, 1) == '-') {
                 $name = substr($name, 1);
                 $readonly = " readonly='true' ";
             }


### PR DESCRIPTION
7.4 will not allow on offset reference on a null without warning.
This affects html.php assumptions of 'null' as empty string placeholder

refs:
issues:  warnings from html.php on 7.4 release

<!-- Have you made sure the following is correct? -->
## Checklist
- [Y] I'm using the correct PHP Version (7.4! for current, 7.0 for legacy).
- [-] Tests are passing - manual observation of use case in custom module, indicating error
- [na ] I've added comments to any new methods I've created or where else relevant.
- [Y] PHPCS has reported no errors to my changes.
- [na] I've replaced magic method usage on DbService classes with the getInstance() static method.

<!-- Add a short description. -->
## 7.4 will not allow on offset reference on a null without warning.

<!-- List your changes as a dot point list. -->
## Replaced string[] references with substr() function in html.php

<!-- Add any important refs or issues numbers. -->
refs:
issues: warnings from html.php on 7.4 release

<!-- Add any other information that might be relevant. -->
## Other Information
