### PR TITLE
fix: twig 3.0

### DIFF
--- a/system/modules/admin/config.php
+++ b/system/modules/admin/config.php
@@ -24,7 +24,7 @@ Config::set('admin', [
     ],
     "dependencies" => [
         "swiftmailer/swiftmailer" => "~6.2",
-        "twig/twig" => "2.4.*",
+        "twig/twig" => "3.0.*",
         "nesbot/carbon" => "1.22.1",
         "robmorgan/phinx" => "0.8.*",
         "sendgrid/sendgrid" => "~5.5",

--- a/system/modules/admin/models/TemplateService.php
+++ b/system/modules/admin/models/TemplateService.php
@@ -1,8 +1,7 @@
 <?php
+
 class TemplateService extends DbService
 {
-    private $twig_lib = "Twig-1.13.2";
-
     /**
      *
      * @param in $id
@@ -104,16 +103,14 @@ class TemplateService extends DbService
         if (is_string($template)) {
             if (file_exists($template)) {
                 $dir = dirname($template);
-                $loader = new Twig_Loader_Filesystem($dir);
+                $loader = new Twig\Loader\FilesystemLoader($dir);
                 $template = str_replace($dir . DIRECTORY_SEPARATOR, "", $template);
-                $twig = new Twig_Environment($loader, array('debug' => true));
-                $twig->addExtension(new Twig_Extension_Debug());
+                $twig = new Twig\Environment($loader, ['debug' => true]);
+                $twig->addExtension(new Twig\Extension\DebugExtension());
                 return $twig->render($template, $data);
             } else {
-                // Latest version of twig deprecates the use of a string loader
-                // https://stackoverflow.com/questions/31081910/what-to-use-instead-of-twig-loader-string
-                $loader = new Twig_Loader_Array([]);
-                $twig = new Twig_Environment($loader, array('debug' => true));
+                $loader = new Twig\Loader\ArrayLoader();
+                $twig = new Twig\Environment($loader, ['debug' => true]);
                 $twig->setCache(false);
                 $template = $twig->createTemplate($template);
                 return $template->render($data);


### PR DESCRIPTION
## Checklist
- [x] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [x] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

## Description
Twig v2.4.x is showing PHP deprecation warnings.

## Changelog
- Updated Twig from v2.4.x to v3.0.x