### PR TITLE
feat: format currency

### DIFF
--- a/system/classes/DbObject.php
+++ b/system/classes/DbObject.php
@@ -184,9 +184,7 @@ class DbObject extends DbService
      * Intermediate method to facilitate transition from
      * selectTitle to getSelectOptionTitle
      *
-     * Will be removed in cmfive v5.x
-     *
-     * @deprecated v3.6.13
+     * @deprecated v3.6.13 - Will be removed in v5.0.0.
      */
     public function _selectOptionTitle()
     {
@@ -696,7 +694,7 @@ class DbObject extends DbService
                 if (substr($k, 0, 1) != "_" && $k != "w" && $v !== null) {
                     $dbk = $this->getDbColumnName($k);
                     $data[$dbk] = $this->updateConvert($dbk, $v);
-  
+
                 }
             }
 
@@ -989,8 +987,9 @@ class DbObject extends DbService
     /**
      * Shorthand function for getDbTableName()
      *
+     * @deprecated v3.6.13 - Will be removed in v5.0.0.
+     *
      * @return string
-     * @deprecated v3.6.13
      */
     public function _tn()
     {
@@ -1000,9 +999,10 @@ class DbObject extends DbService
     /**
      * Shorthand function for getDbColumnName()
      *
+     * @deprecated v3.6.13 - Will be removed in v5.0.0.
+     *
      * @param string $attr
      * @return string
-     * @deprecated v3.6.13
      */
     public function _cn($attr)
     {
@@ -1054,7 +1054,7 @@ class DbObject extends DbService
      */
     public function addToIndex()
     {
-        
+
     }
 
     /**
@@ -1072,7 +1072,7 @@ class DbObject extends DbService
     // a list of english words that need not be searched against
     // and thus do not need to be stored in an index
 
-    
+
     /**
      * Consolidate all object fields into one big search friendly string.
      *

--- a/system/classes/DbPDO.php
+++ b/system/classes/DbPDO.php
@@ -269,7 +269,8 @@ class DbPDO extends PDO
     }
 
     /**
-     * @deprecated v3.0.0 - Will be removed in v5.0.0, see DbPDO::orderBy().
+     * @deprecated v3.0.0 - Will be removed in v5.0.0.
+     * @see DbPDO::orderBy()
      */
     public function order_by($orderby)
     {
@@ -356,7 +357,8 @@ class DbPDO extends PDO
     }
 
     /**
-     * @deprecated v3.0.0 - Will be removed in v5.0.0, see DbPDO::fetchElement().
+     * @deprecated v3.0.0 - Will be removed in v5.0.0.
+     * @see DbPDO::fetchElement()
      */
     public function fetch_element($element)
     {
@@ -375,7 +377,8 @@ class DbPDO extends PDO
     }
 
     /**
-     * @deprecated v3.0.0 - Will be removed in v5.0.0, see DbPDO::fetchRow().
+     * @deprecated v3.0.0 - Will be removed in v5.0.0.
+     * @see DbPDO::fetchRow()
      */
     public function fetch_row()
     {
@@ -399,7 +402,8 @@ class DbPDO extends PDO
     }
 
     /**
-     * @deprecated v3.0.0 - Will be removed in v5.0.0, see DbPDO::fetchAll().
+     * @deprecated v3.0.0 - Will be removed in v5.0.0.
+     * @see DbPDO::fetchAll()
      */
     public function fetch_all()
     {
@@ -567,7 +571,8 @@ class DbPDO extends PDO
     }
 
     /**
-     * @deprecated v3.0.0 - Will be removed in v5.0.0, see DbPDO::clearSql().
+     * @deprecated v3.0.0 - Will be removed in v5.0.0.
+     * @see DbPDO::clearSql()
      */
     public function clear_sql()
     {

--- a/system/classes/DbPDO.php
+++ b/system/classes/DbPDO.php
@@ -269,8 +269,7 @@ class DbPDO extends PDO
     }
 
     /**
-     * @deprecated v3.0.0
-     * @see DbPDO::orderBy()
+     * @deprecated v3.0.0 - Will be removed in v5.0.0, see DbPDO::orderBy().
      */
     public function order_by($orderby)
     {
@@ -357,8 +356,7 @@ class DbPDO extends PDO
     }
 
     /**
-     * @deprecated v3.0.0
-     * @see DbPDO::fetchElement()
+     * @deprecated v3.0.0 - Will be removed in v5.0.0, see DbPDO::fetchElement().
      */
     public function fetch_element($element)
     {
@@ -377,8 +375,7 @@ class DbPDO extends PDO
     }
 
     /**
-     * @deprecated v3.0.0
-     * @see DbPDO::fetchRow()
+     * @deprecated v3.0.0 - Will be removed in v5.0.0, see DbPDO::fetchRow().
      */
     public function fetch_row()
     {
@@ -402,8 +399,7 @@ class DbPDO extends PDO
     }
 
     /**
-     * @deprecated v3.0.0
-     * @see DbPDO::fetchAll()
+     * @deprecated v3.0.0 - Will be removed in v5.0.0, see DbPDO::fetchAll().
      */
     public function fetch_all()
     {
@@ -571,8 +567,7 @@ class DbPDO extends PDO
     }
 
     /**
-     * @deprecated v3.0.0
-     * @see DbPDO::clearSql()
+     * @deprecated v3.0.0 - Will be removed in v5.0.0, see DbPDO::clearSql().
      */
     public function clear_sql()
     {

--- a/system/classes/DbService.php
+++ b/system/classes/DbService.php
@@ -32,7 +32,8 @@ class DbService
     /**
      * Magic get implementation to pass to Web, returns a {$name}Service singleton
      *
-     * @deprecated v3.6
+     * @deprecated v3.6.0 - Will be removed in v5.0.0.
+     *
      * @param string
      * @return mixed|null
      */

--- a/system/classes/JsonResponse.php
+++ b/system/classes/JsonResponse.php
@@ -89,7 +89,8 @@ class JsonResponse
     /**
      * Shorthand function for creating a not found (404) response
      *
-     * @deprecated v3.6.13
+     * @deprecated v3.6.13 - Will be removed in v5.0.0.
+     *
      * @param string $message
      * @return self
      */

--- a/system/functions.php
+++ b/system/functions.php
@@ -164,8 +164,9 @@ function humanReadableBytes($input, $rounding = 2, $bytesValue = true)
 }
 
 /**
- * DEPRECATED from v3.0.0
- * Returns the extension for given content type
+ * Returns the extension for given content type.
+ *
+ * @deprecated v3.0.0 - Will be removed in v5.0.0.
  *
  * @param string contentType
  * @return string extension
@@ -326,10 +327,10 @@ function rotateImage($img, $rotation)
 }
 
 /**
- * DEPRECATED from v3.0.0 - use LookupService::lookupForSelect instead
- *
  * Returns a lookup by type from the database and formats
- * it ready for a Html::select field
+ * it ready for a Html::select field.
+ *
+ * @deprecated v3.0.0 - Will be removed in v5.0.0, see LookupService::lookupForSelect().
  *
  * @param Web $w
  * @param string type
@@ -348,9 +349,9 @@ function lookupForSelect($w, $type)
 }
 
 /**
- * DEPRECATED from v3.0.0 - define this whenever needed in your module
+ * Returns a list of states of Australia structured for a Html::select field.
  *
- * Returns a list of states of Australia structured for a Html::select field
+ * @deprecated v3.0.0 - Will be removed in v5.0.0, define this whenever needed in your module.
  *
  * @return Array states
  */
@@ -522,121 +523,32 @@ function formatNumber($number)
 }
 
 /**
+ * Formats a float value into a valid currency string based on the $locale and $currency parameters.
+ *
+ * @param float $value
+ * @param string $locale
+ * @param string $currency
+ * @return string
+ */
+function formatCurrency(float $value, string $locale = "en_AU", string $currency = "AUD"): string
+{
+    return (new NumberFormatter($locale, NumberFormatter::CURRENCY))->formatCurrency($value, $currency);
+}
+
+/**
  * A replacement function for the money_format PHP function that is only
  * available on most Linux based systems with the strfmon C function.
  *
  * For those that do not (Windows), then the function is imitated with code.
+ *
+ * @deprecated v4.0.6 - Will be removed in v5.0.0, see formatCurrency().
  *
  * @param string format
  * @param float|mixed number
  */
 function formatMoney($format, $number)
 {
-    if (function_exists('money_format')) {
-        setlocale(LC_MONETARY, 'en_AU');
-        $formatter = new NumberFormatter("en_AU", NumberFormatter::CURRENCY);
-        return $formatter->formatCurrency(doubleval($number), "AUD");
-        // return money_format($format, doubleval($number));
-    }
-
-    $regex = '/%((?:[\^!\-]|\+|\(|\=.)*)([0-9]+)?' .
-        '(?:#([0-9]+))?(?:\.([0-9]+))?([in%])/';
-    if (setlocale(LC_MONETARY, 0) == 'C') {
-        setlocale(LC_MONETARY, '');
-    }
-
-    $locale = localeconv();
-    if (empty($locale['mon_decimal_point'])) {
-        $locale['mon_decimal_point'] = ".";
-    }
-
-    if (empty($locale['mon_thousands_sep'])) {
-        $locale['mon_thousands_sep'] = ",";
-    }
-
-    preg_match_all($regex, $format, $matches, PREG_SET_ORDER);
-
-    foreach ($matches ?? [] as $fmatch) {
-        $value = floatval($number);
-        $flags = [
-            'fillchar' => preg_match('/\=(.)/', $fmatch[1], $fmatch) ? $fmatch[1] : ' ',
-            'nogroup' => preg_match('/\^/', $fmatch[1]) > 0,
-            'usesignal' => preg_match('/\+|\(/', $fmatch[1], $fmatch) ? $fmatch[0] : '+',
-            'nosimbol' => preg_match('/\!/', $fmatch[1]) > 0,
-            'isleft' => preg_match('/\-/', $fmatch[1]) > 0,
-        ];
-
-        $width = trim($fmatch[2]) ? intval($fmatch[2]) : 0;
-        $left = trim($fmatch[3]) ? intval($fmatch[3]) : 0;
-        $right = trim($fmatch[4]) ? intval($fmatch[4]) : $locale['int_frac_digits'];
-        $conversion = $fmatch[5];
-
-        $positive = true;
-        if ($value < 0) {
-            $positive = false;
-            $value *= -1;
-        }
-
-        $letter = $positive ? 'p' : 'n';
-
-        $prefix = $suffix = $cprefix = $csuffix = $signal = '';
-
-        $signal = $positive ? $locale['positive_sign'] : $locale['negative_sign'];
-        switch (true) {
-            case $locale["{$letter}_sign_posn"] == 1 && $flags['usesignal'] == '+':
-                $prefix = $signal;
-                break;
-            case $locale["{$letter}_sign_posn"] == 2 && $flags['usesignal'] == '+':
-                $suffix = $signal;
-                break;
-            case $locale["{$letter}_sign_posn"] == 3 && $flags['usesignal'] == '+':
-                $cprefix = $signal;
-                break;
-            case $locale["{$letter}_sign_posn"] == 4 && $flags['usesignal'] == '+':
-                $csuffix = $signal;
-                break;
-            case $flags['usesignal'] == '(':
-            case $locale["{$letter}_sign_posn"] == 0:
-                $prefix = '(';
-                $suffix = ')';
-                break;
-        }
-
-        if (!$flags['nosimbol']) {
-            $currency = $cprefix .
-                ($conversion == 'i' ? $locale['int_curr_symbol'] : $locale['currency_symbol']) .
-                $csuffix;
-        } else {
-            $currency = '';
-        }
-
-        $space = $locale["{$letter}_sep_by_space"] ? ' ' : '';
-        $value = number_format($value, $right, $locale['mon_decimal_point'], $flags['nogroup'] ? '' : $locale['mon_thousands_sep']);
-        $value = @explode($locale['mon_decimal_point'], $value);
-
-        $n = strlen($prefix) + strlen($currency) + strlen($value[0]);
-        if ($left > 0 && $left > $n) {
-            $value[0] = str_repeat($flags['fillchar'], $left - $n) . $value[0];
-        }
-
-        if (!empty($value)) {
-            $value = implode($locale['mon_decimal_point'], $value);
-        }
-
-        if ($locale["{$letter}_cs_precedes"]) {
-            $value = $prefix . $currency . $space . $value . $suffix;
-        } else {
-            $value = $prefix . $value . $space . $currency . $suffix;
-        }
-
-        if ($width > 0) {
-            $value = str_pad($value, $width, $flags['fillchar'], $flags['isleft'] ?
-                STR_PAD_RIGHT : STR_PAD_LEFT);
-        }
-
-        $format = str_replace($fmatch[0], $value, $format);
-    }
-    return trim($format);
+    return formatCurrency($number);
 }
 
 /**
@@ -673,7 +585,7 @@ function recursiveArraySearch($haystack, $needle, $index = null)
  * To use this function, use the list function, calling this function.
  * i.e. list($from_date, $to_date) = returncorrectdates($w,$dm_var,$from_date,$to_date);
  *
- * @deprecated v3.0.0
+ * @deprecated v3.0.0 - Will be removed in v5.0.0.
  *
  * @param Web $w
  * @param string $dm_var
@@ -840,9 +752,9 @@ function in_modified_multiarray($value, $array, $levels = 3)
 }
 
 /**
- * Returns AES encrypted string - will now use new SSLEncrypt function
+ * Returns AES encrypted string.
  *
- * @deprecated v3.0.0
+ * @deprecated v3.0.0 - Will be removed in v5.0.0, see SSLEncrypt().
  *
  * @param mixed text to encrypt
  * @param mixed password (unused)
@@ -854,9 +766,9 @@ function AESencrypt($text, $password)
 }
 
 /**
- * Decrypts AES string - will now use new SSLDecrypt function
+ * Decrypts AES string.
  *
- * @deprecated v3.0.0
+ * @deprecated v3.0.0 - Will be removed in v5.0.0, see SSLDecrypt().
  *
  * @param mixed text to decrypt
  * @param mixed password (unused)

--- a/system/functions.php
+++ b/system/functions.php
@@ -330,7 +330,8 @@ function rotateImage($img, $rotation)
  * Returns a lookup by type from the database and formats
  * it ready for a Html::select field.
  *
- * @deprecated v3.0.0 - Will be removed in v5.0.0, see LookupService::lookupForSelect().
+ * @deprecated v3.0.0 - Will be removed in v5.0.0.
+ * @see LookupService::lookupForSelect()
  *
  * @param Web $w
  * @param string type
@@ -541,7 +542,8 @@ function formatCurrency(float $value, string $locale = "en_AU", string $currency
  *
  * For those that do not (Windows), then the function is imitated with code.
  *
- * @deprecated v4.0.6 - Will be removed in v5.0.0, see formatCurrency().
+ * @deprecated v4.0.6 - Will be removed in v5.0.0.
+ * @see formatCurrency()
  *
  * @param string format
  * @param float|mixed number
@@ -754,7 +756,8 @@ function in_modified_multiarray($value, $array, $levels = 3)
 /**
  * Returns AES encrypted string.
  *
- * @deprecated v3.0.0 - Will be removed in v5.0.0, see SSLEncrypt().
+ * @deprecated v3.0.0 - Will be removed in v5.0.0.
+ * @see SSLEncrypt()
  *
  * @param mixed text to encrypt
  * @param mixed password (unused)
@@ -768,7 +771,8 @@ function AESencrypt($text, $password)
 /**
  * Decrypts AES string.
  *
- * @deprecated v3.0.0 - Will be removed in v5.0.0, see SSLDecrypt().
+ * @deprecated v3.0.0 - Will be removed in v5.0.0.
+ * @see SSLDecrypt()
  *
  * @param mixed text to decrypt
  * @param mixed password (unused)

--- a/system/modules/admin/models/AwsTransport.php
+++ b/system/modules/admin/models/AwsTransport.php
@@ -66,24 +66,20 @@ class AwsTransport implements GenericTransport
 
         $queue_url = Config::get("admin.mail.aws.queue_url");
         if (empty($queue_url)) {
-            LogService::getInstance($this->w)->error("Failed to send mail to: $to, from: $reply_to, about: $subject: admin.mail.aws.queue_url not set in config");
+            LogService::getInstance($this->w)->setLogger("EMAIL")->error("Failed to send mail to: $to, from: $reply_to, about: $subject: admin.mail.aws.queue_url not set in config");
             return;
         }
 
         $from_arn = Config::get("admin.mail.aws.from_arn");
-        if (empty($from_arn)) {
-            LogService::getInstance($this->w)->error("Failed to send mail to: $to, from: $reply_to, about: $subject: admin.mail.aws.from_arn not set in config");
-            return;
-        }
 
         $from = Config::get("main.company_support_email");
         if (empty($from)) {
-            $this->w->Log->error("Failed to send mail to: $to, from: $reply_to, about: $subject: main.company_support_email not set in config");
+            LogService::getInstance($this->w)->setLogger("EMAIL")->error("Failed to send mail to: $to, from: $reply_to, about: $subject: main.company_support_email not set in config");
             return;
         }
 
         if (empty($to) || strlen($to) === 0) {
-            LogService::getInstance($this->w)->error("Failed to send mail to: $to, from: $reply_to, about: $subject: no recipients");
+            LogService::getInstance($this->w)->setLogger("EMAIL")->error("Failed to send mail to: $to, from: $reply_to, about: $subject: no recipients");
             return;
         }
 

--- a/system/modules/admin/models/MandrillTransport.php
+++ b/system/modules/admin/models/MandrillTransport.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @deprecated v3.7.1
+ * @deprecated v3.7.1 - Will be removed in v5.0.0.
  */
 class MandrillTransport implements GenericTransport
 {

--- a/system/modules/auth/models/User.php
+++ b/system/modules/auth/models/User.php
@@ -35,7 +35,7 @@ class User extends DbObject
     /**
      * Checks if the passed password matches the stored password when hashed.
      *
-     * @deprecated v3.0.0
+     * @deprecated v3.0.0 - Will be removed in v5.0.0.
      *
      * @param string $password
      *

--- a/system/modules/channels/models/ChannelService.php
+++ b/system/modules/channels/models/ChannelService.php
@@ -138,9 +138,11 @@ class ChannelService extends DbService
 
     /**
      * Get new messages using a sql query
+     *
+     * @deprecated v2.12.1 - Will be removed in v5.0.0, see ChannelProcessor->getnewmessages().
+     *
      * @param  int $channel_id   [description]
      * @param  int $processor_id [description]
-     * @deprecated does not consider whether the message is processed. Used channelprocessor->getnewmessages() instead
      */
     public function getNewMessages($channel_id, $processor_id)
     {

--- a/system/modules/channels/models/ChannelService.php
+++ b/system/modules/channels/models/ChannelService.php
@@ -139,7 +139,8 @@ class ChannelService extends DbService
     /**
      * Get new messages using a sql query
      *
-     * @deprecated v2.12.1 - Will be removed in v5.0.0, see ChannelProcessor->getnewmessages().
+     * @deprecated v2.12.1 - Will be removed in v5.0.0.
+     * @see ChannelProcessor->getnewmessages()
      *
      * @param  int $channel_id   [description]
      * @param  int $processor_id [description]

--- a/system/modules/file/models/FileService.php
+++ b/system/modules/file/models/FileService.php
@@ -54,7 +54,8 @@ class FileService extends DbService
     /**
      * Return the path adjusted to the currently active adapter.
      *
-     * @deprecated v3.6
+     * @deprecated v3.6.0 - Will be removed in v5.0.0.
+     *
      * @param string file path
      *
      * @return string resulting file path

--- a/system/modules/form/models/FormInstance.php
+++ b/system/modules/form/models/FormInstance.php
@@ -83,7 +83,8 @@ class FormInstance extends DbObject
     /**
      * Returns an array of values from an SQL view.
      *
-     * @deprecated v3.0.0
+     * @deprecated v3.0.0 - Will be removed in v5.0.0.
+     *
      * @return array
      */
     public function getValuesArray()

--- a/system/modules/main/models/HttpRequest.php
+++ b/system/modules/main/models/HttpRequest.php
@@ -82,7 +82,8 @@ class HttpRequest
     /**
      * Runs the request.
      *
-     * @deprecated 2.14.5 - Will be removed in v5.0.0, see HttpRequest::execute().
+     * @deprecated 2.14.5 - Will be removed in v5.0.0.
+     * @see HttpRequest::execute()
      *
      * @param string $output
      * @param string $error

--- a/system/modules/main/models/HttpRequest.php
+++ b/system/modules/main/models/HttpRequest.php
@@ -1,91 +1,98 @@
 <?php
 
-class HttpRequest {
-	
-	public $url = '';
-	public $data = [];
-	public $method = 'GET';
+class HttpRequest
+{
 
-	private $curl_handle;
+    public $url = '';
+    public $data = [];
+    public $method = 'GET';
 
-	public function __construct($url, $method = 'GET', $data = []) {
-		$this->curl_handle = curl_init();
-		
-		$this->url = $url;
-		$this->method = $method;
-		$this->data = $data;
+    private $curl_handle;
 
-		switch(strtoupper($method)) {
-			case 'POST': {
-				curl_setopt($this->curl_handle, CURLOPT_URL, $url);
-				curl_setopt($this->curl_handle, CURLOPT_POST, 1);
-				curl_setopt($this->curl_handle, CURLOPT_POSTFIELDS, $this->data);
-				break;
-			};
-			case 'DELETE':
-					curl_setopt_array($this->curl_handle, [
-						CURLOPT_URL => $url,
-						CURLOPT_CUSTOMREQUEST => "DELETE"
-					]);
-				break;
-			case 'GET':
-			default:
-				curl_setopt($this->curl_handle, CURLOPT_URL, $url . (!empty($data) && is_array($data) ? '?' . http_build_query($data) : ''));
-		}
-		curl_setopt($this->curl_handle, CURLOPT_RETURNTRANSFER, true);
+    public function __construct($url, $method = 'GET', $data = [])
+    {
+        $this->curl_handle = curl_init();
 
-		return $this;
-	}
+        $this->url = $url;
+        $this->method = $method;
+        $this->data = $data;
 
-	public function __destruct() {
-		curl_close($this->curl_handle);
-	}
+        switch (strtoupper($method)) {
+            case 'POST': {
+                    curl_setopt($this->curl_handle, CURLOPT_URL, $url);
+                    curl_setopt($this->curl_handle, CURLOPT_POST, 1);
+                    curl_setopt($this->curl_handle, CURLOPT_POSTFIELDS, $this->data);
+                    break;
+            };
+            case 'DELETE':
+                curl_setopt_array($this->curl_handle, [
+                    CURLOPT_URL => $url,
+                    CURLOPT_CUSTOMREQUEST => "DELETE"
+                ]);
+                break;
+            case 'GET':
+            default:
+                curl_setopt($this->curl_handle, CURLOPT_URL, $url . (!empty($data) && is_array($data) ? '?' . http_build_query($data) : ''));
+        }
+        curl_setopt($this->curl_handle, CURLOPT_RETURNTRANSFER, true);
 
-	public function setOpt($callback = null) {
-		if (is_callable($callback)) {
-			$callback($this->curl_handle);
-		}
+        return $this;
+    }
 
-		return $this;
-	}
+    public function __destruct()
+    {
+        curl_close($this->curl_handle);
+    }
 
-	/**
-	 * Adds Basic Authenication to the request.
-	 *
-	 * @param string $username
-	 * @param string $password
-	 * @return void
-	 */
-	public function setBasicAuth($username = "", $password = "") {
-		curl_setopt($this->curl_handle, CURLOPT_USERPWD, $username . ":" . $password);
-	}
+    public function setOpt($callback = null)
+    {
+        if (is_callable($callback)) {
+            $callback($this->curl_handle);
+        }
 
-	/**
-	 * Executes the request and returns the response data, status code & error message.
-	 *
-	 * @return array[string]
-	 */
-	public function execute() {
-		$data = curl_exec($this->curl_handle);
-		$status_code = curl_getinfo($this->curl_handle, CURLINFO_HTTP_CODE);
-		$error_message = curl_error($this->curl_handle);
+        return $this;
+    }
 
-		return ["status_code" => $status_code, "data" => $data, "error" => $error_message];
-	}
+    /**
+     * Adds Basic Authenication to the request.
+     *
+     * @param string $username
+     * @param string $password
+     * @return void
+     */
+    public function setBasicAuth($username = "", $password = "")
+    {
+        curl_setopt($this->curl_handle, CURLOPT_USERPWD, $username . ":" . $password);
+    }
 
-	/**
-	 * Runs the request.
-	 *
-	 * @deprecated 2.14.5 - Use simplified function execute instead.
-	 *
-	 * @param string $output
-	 * @param string $error
-	 * @return string
-	 */
-	public function run(&$output, &$error) {
-		$response = $this->execute();
-		$output = $response["data"];
-		$error = $response["error_message"];
-		return $output;
-	}
+    /**
+     * Executes the request and returns the response data, status code & error message.
+     *
+     * @return array[string]
+     */
+    public function execute()
+    {
+        $data = curl_exec($this->curl_handle);
+        $status_code = curl_getinfo($this->curl_handle, CURLINFO_HTTP_CODE);
+        $error_message = curl_error($this->curl_handle);
+
+        return ["status_code" => $status_code, "data" => $data, "error" => $error_message];
+    }
+
+    /**
+     * Runs the request.
+     *
+     * @deprecated 2.14.5 - Will be removed in v5.0.0, see HttpRequest::execute().
+     *
+     * @param string $output
+     * @param string $error
+     * @return string
+     */
+    public function run(&$output, &$error)
+    {
+        $response = $this->execute();
+        $output = $response["data"];
+        $error = $response["error_message"];
+        return $output;
+    }
 }

--- a/system/modules/main/tests/unit/FunctionsTest.php
+++ b/system/modules/main/tests/unit/FunctionsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class FunctionsTest extends TestCase
+{
+    /**
+     * Test formatCurrency() in functions.php.
+     *
+     * @return void
+     */
+    public function testFormatCurrency(): void
+    {
+        require_once("system/web.php");
+        $w = new Web();
+
+        $testCases = [
+            ["value" => -1, "locale" => "en_AU", "currency" => "AUD", "want" => "-$1.00"],
+            ["value" => -1.55, "locale" => "en_AU", "currency" => "AUD", "want" => "-$1.55"],
+            ["value" => -1.555, "locale" => "en_AU", "currency" => "AUD", "want" => "-$1.56"],
+            ["value" => 0, "locale" => "en_AU", "currency" => "AUD", "want" => "$0.00"],
+            ["value" => 0.55, "locale" => "en_AU", "currency" => "AUD", "want" => "$0.55"],
+            ["value" => 0.555, "locale" => "en_AU", "currency" => "AUD", "want" => "$0.56"],
+            ["value" => 1, "locale" => "en_AU", "currency" => "AUD", "want" => "$1.00"],
+            ["value" => 1.55, "locale" => "en_AU", "currency" => "AUD", "want" => "$1.55"],
+            ["value" => 1.555, "locale" => "en_AU", "currency" => "AUD", "want" => "$1.56"],
+        ];
+
+        foreach ($testCases as $testCase) {
+            $this->assertEquals($testCase["want"], formatCurrency($testCase["value"], $testCase["locale"], $testCase["currency"]));
+        }
+    }
+}

--- a/system/modules/task/models/TaskGroupType.php
+++ b/system/modules/task/models/TaskGroupType.php
@@ -115,7 +115,8 @@ abstract class TaskGroupType
      * By default returns the very first status of the
      * status array if defined. Otherwise "".
      *
-     * @deprecated v2.0.0 - Will be removed in v5.0.0, see TaskGroupType::getDefaultStatus().
+     * @deprecated v2.0.0 - Will be removed in v5.0.0.
+     * @see TaskGroupType::getDefaultStatus()
      */
     public function get_default_status()
     {

--- a/system/modules/task/models/TaskGroupType.php
+++ b/system/modules/task/models/TaskGroupType.php
@@ -1,192 +1,211 @@
 <?php
+
 /**
- * Defines the different types of tasks which 
+ * Defines the different types of tasks which
  * can be assigned in a Task group.
- * 
+ *
  * @author carsten
  *
  */
-abstract class TaskGroupType {
-	public $w;
-	
-	function __construct(Web $w){
-		$this->w = $w;	
-	}
-	
-	/**
-	 * Returns the title for the type
-	 * - override in subclass
-	 * - or specify in config.php using key 'task.<subclassname>.can-task-reopen'
-	 */
-	function getTaskGroupTypeTitle() {
-		$value = Config::get("task.".get_class($this).".title");
-		return !empty($value) ? $value : false;
-	}
-	
-	/**
-	 * Specifies if a closed task can be reopened
-	 * - override in subclass
-	 * - or specify in config.php using key 'task.<subclassname>.can-task-reopen'
-	 * 
-	 * @return boolean
-	 */
-	function getCanTaskGroupReopen() {
-		$value = Config::get("task.".get_class($this).".can-task-reopen");
-		return !empty($value) ? $value : false;
-	}
-	
-	/**
-	 * Return the description for this type
-	 * - override in subclass
-	 * - or specify in config.php with key 'task.<subclassname>.description'
-	 */
-	function getTaskGroupTypeDescription() {
-		$value = Config::get("task.".get_class($this).".description");
-		return !empty($value) ? $value : false;
-	}
-	
-	/**
-	 * Return array of php class names of concrete
-	 * implementations of abstract TaskType
-	 * - override in subclass
-	 * - or specify in config.php with key 'task.<subclassname>.tasktypes'
-	 */
-	function getTaskTypeArray() {
-		$value = Config::get("task.".get_class($this).".tasktypes");
-		return !empty($value) ? $value : false;
-	}
-	
-	/**
-	 * Return array containing all
-	 * available statuses for tasks in 
-	 * this group
-	 * - override in subclass
-	 * - or specify in config.php with key 'task.<subclassname>.statuses'
-	 */
-	function getStatusArray() {
-		$value = Config::get("task.".get_class($this).".statuses");
-		return !empty($value) ? $value : false;
-	}
-	
-	/**
-	 * Return array of all available
-	 * priorities in this group
-	 * - override in subclass
-	 * - or specify in config.php with key 'task.<subclassname>.priorities'
-	 */
-	function getTaskPriorityArray() {
-		$value = Config::get("task.".get_class($this).".priorities");
-		return !empty($value) ? $value : false;
-	}
+abstract class TaskGroupType
+{
+    public $w;
 
-	/**
-	 * Returns whether or not the given tasks priority is urgent
-	 * 
-	 * @param String priority
-	 * @return boolean
-	 */
-	function isUrgentPriority($priority) {
-		$urgent_priorities = Config::get("task.".get_class($this).".urgent-priorities");
-		if (is_array($urgent_priorities) && count($urgent_priorities) > 0 && !empty($priority)) {
-			return in_array($priority, $urgent_priorities);
-		}
-		return false;
-	}
-	
-	/**
-	 * Return array of task permissions
-	 * 
-	 */
-	function getPermissionsArray() {
-	}
-	
-	/**
-	 * By default returns the very first status of the
-	 * status array if defined. Otherwise "".
-	 * @deprecated use getDefaultStatus instead
-	 */
-	function get_default_status() {
-		return $this->getDefaultStatus();
-	}	
-	
-	/**
-	 * By default returns the very first status of the
-	 * status array if defined. Otherwise "".
-	 * - override in subclass
-	 * - or specify in config.php with key 'task.<subclassname>.default-status'
-	 */
-	function getDefaultStatus() {
-		$value = Config::get("task.".get_class($this).".default-status");
-		if (!empty($value)) {
-			return $value;
-		} else {
-			$statusarray = $this->getStatusArray();
-			if (!empty($statusarray) && sizeof($statusarray) > 0) {
-				return $statusarray[0][0];
-			} else {
-				return "";
-			}
-		}
-	}
-	/**
-	 * Executed before a task is inserted into DB
-	 * 
-	 * @param Task $task
-	 */
-	function on_before_insert(Task $task) {
-		if (!empty($task)) {
-			$task->w->callHook("task", get_class($this)."_on_before_insert", $task);
-		}
-	}	
-	/**
-	 * Executed after a task has been inserted into DB
-	 * 
-	 * @param Task $task
-	 */
-	function on_after_insert(Task $task) {
-		if (!empty($task)) {
-			$task->w->callHook("task", get_class($this)."_on_after_insert", $task);
-		}
-	}	
-	/**
-	 * Executed before a task is updated in the DB
-	 * 
-	 * @param Task $task
-	 */
-	function on_before_update(Task $task) {
-		if (!empty($task)) {
-			$task->w->callHook("task", get_class($this)."_on_before_update", $task);
-		}
-	}	
-	/**
-	 * Executed after a task has been updated in the DB
-	 * 
-	 * @param Task $task
-	 */
-	function on_after_update(Task $task) {
-		if (!empty($task)) {
-			$task->w->callHook("task", get_class($this)."_on_after_update", $task);
-		}
-	}	
-	/**
-	 * Executed before a task is deleted from the DB
-	 * 
-	 * @param Task $task
-	 */
-	function on_before_delete(Task $task) {
-		if (!empty($task)) {
-			$task->w->callHook("task", get_class($this)."_on_before_delete", $task);
-		}
-	}	
-	/**
-	 * Executed after a task has been deleted from the DB
-	 * 
-	 * @param Task $task
-	 */
-	function on_after_delete(Task $task) {
-		if (!empty($task)) {
-			$task->w->callHook("task", get_class($this)."_on_after_delete", $task);
-		}
-	}
-		
+    public function __construct(Web $w)
+    {
+        $this->w = $w;
+    }
+
+    /**
+     * Returns the title for the type
+     * - override in subclass
+     * - or specify in config.php using key 'task.<subclassname>.can-task-reopen'
+     */
+    public function getTaskGroupTypeTitle()
+    {
+        $value = Config::get("task." . get_class($this) . ".title");
+        return !empty($value) ? $value : false;
+    }
+
+    /**
+     * Specifies if a closed task can be reopened
+     * - override in subclass
+     * - or specify in config.php using key 'task.<subclassname>.can-task-reopen'
+     *
+     * @return boolean
+     */
+    public function getCanTaskGroupReopen()
+    {
+        $value = Config::get("task." . get_class($this) . ".can-task-reopen");
+        return !empty($value) ? $value : false;
+    }
+
+    /**
+     * Return the description for this type
+     * - override in subclass
+     * - or specify in config.php with key 'task.<subclassname>.description'
+     */
+    public function getTaskGroupTypeDescription()
+    {
+        $value = Config::get("task." . get_class($this) . ".description");
+        return !empty($value) ? $value : false;
+    }
+
+    /**
+     * Return array of php class names of concrete
+     * implementations of abstract TaskType
+     * - override in subclass
+     * - or specify in config.php with key 'task.<subclassname>.tasktypes'
+     */
+    public function getTaskTypeArray()
+    {
+        $value = Config::get("task." . get_class($this) . ".tasktypes");
+        return !empty($value) ? $value : false;
+    }
+
+    /**
+     * Return array containing all
+     * available statuses for tasks in
+     * this group
+     * - override in subclass
+     * - or specify in config.php with key 'task.<subclassname>.statuses'
+     */
+    public function getStatusArray()
+    {
+        $value = Config::get("task." . get_class($this) . ".statuses");
+        return !empty($value) ? $value : false;
+    }
+
+    /**
+     * Return array of all available
+     * priorities in this group
+     * - override in subclass
+     * - or specify in config.php with key 'task.<subclassname>.priorities'
+     */
+    public function getTaskPriorityArray()
+    {
+        $value = Config::get("task." . get_class($this) . ".priorities");
+        return !empty($value) ? $value : false;
+    }
+
+    /**
+     * Returns whether or not the given tasks priority is urgent
+     *
+     * @param String priority
+     * @return boolean
+     */
+    public function isUrgentPriority($priority)
+    {
+        $urgent_priorities = Config::get("task." . get_class($this) . ".urgent-priorities");
+        if (is_array($urgent_priorities) && count($urgent_priorities) > 0 && !empty($priority)) {
+            return in_array($priority, $urgent_priorities);
+        }
+        return false;
+    }
+
+    /**
+     * Return array of task permissions
+     *
+     */
+    public function getPermissionsArray()
+    {
+    }
+
+    /**
+     * By default returns the very first status of the
+     * status array if defined. Otherwise "".
+     *
+     * @deprecated v2.0.0 - Will be removed in v5.0.0, see TaskGroupType::getDefaultStatus().
+     */
+    public function get_default_status()
+    {
+        return $this->getDefaultStatus();
+    }
+
+    /**
+     * By default returns the very first status of the
+     * status array if defined. Otherwise "".
+     * - override in subclass
+     * - or specify in config.php with key 'task.<subclassname>.default-status'
+     */
+    public function getDefaultStatus()
+    {
+        $value = Config::get("task." . get_class($this) . ".default-status");
+        if (!empty($value)) {
+            return $value;
+        } else {
+            $statusarray = $this->getStatusArray();
+            if (!empty($statusarray) && sizeof($statusarray) > 0) {
+                return $statusarray[0][0];
+            } else {
+                return "";
+            }
+        }
+    }
+    /**
+     * Executed before a task is inserted into DB
+     *
+     * @param Task $task
+     */
+    public function on_before_insert(Task $task)
+    {
+        if (!empty($task)) {
+            $task->w->callHook("task", get_class($this) . "_on_before_insert", $task);
+        }
+    }
+    /**
+     * Executed after a task has been inserted into DB
+     *
+     * @param Task $task
+     */
+    public function on_after_insert(Task $task)
+    {
+        if (!empty($task)) {
+            $task->w->callHook("task", get_class($this) . "_on_after_insert", $task);
+        }
+    }
+    /**
+     * Executed before a task is updated in the DB
+     *
+     * @param Task $task
+     */
+    public function on_before_update(Task $task)
+    {
+        if (!empty($task)) {
+            $task->w->callHook("task", get_class($this) . "_on_before_update", $task);
+        }
+    }
+    /**
+     * Executed after a task has been updated in the DB
+     *
+     * @param Task $task
+     */
+    public function on_after_update(Task $task)
+    {
+        if (!empty($task)) {
+            $task->w->callHook("task", get_class($this) . "_on_after_update", $task);
+        }
+    }
+    /**
+     * Executed before a task is deleted from the DB
+     *
+     * @param Task $task
+     */
+    public function on_before_delete(Task $task)
+    {
+        if (!empty($task)) {
+            $task->w->callHook("task", get_class($this) . "_on_before_delete", $task);
+        }
+    }
+    /**
+     * Executed after a task has been deleted from the DB
+     *
+     * @param Task $task
+     */
+    public function on_after_delete(Task $task)
+    {
+        if (!empty($task)) {
+            $task->w->callHook("task", get_class($this) . "_on_after_delete", $task);
+        }
+    }
 }

--- a/system/modules/task/models/TaskType.php
+++ b/system/modules/task/models/TaskType.php
@@ -118,7 +118,8 @@ abstract class TaskType
      * Return a html string which will be displayed alongside
      * the generic task details.
      *
-     * @deprecated this should move out into a hook called from the task template!
+     * @deprecated v2.0.0 - Will be removed in v5.0.0.
+     *
      * @param Task $task
      */
     public function displayExtraDetails(Task $task)
@@ -128,7 +129,8 @@ abstract class TaskType
     /**
      * Return a Html string which will be appended to the row of buttons in the viewtask screen.
      *
-     * @deprecated this should move out into a hook called from the task template!
+     * @deprecated v2.0.0 - Will be removed in v5.0.0.
+     *
      * @param Task $task
      */
     public function displayExtraButtons(Task $task)

--- a/system/web.php
+++ b/system/web.php
@@ -431,11 +431,10 @@ class Web
 
     /**
      * Performs comparison for weights (for the enqueue functions above) to sort
-     * by the "weight" key in descending order
+     * by the "weight" key in descending order.
      *
-     * Will be removed in v4
+     * @deprecated v3.6.13 - Will be removed in v5.0.0.
      *
-     * @deprecated v3.6.13
      * @param Array $a
      * @param Array $b
      * @return int
@@ -913,7 +912,8 @@ class Web
      * Returns a service class instance that matches the name given,
      * E.g. $w->Inbox->... would return an InboxService class instance.
      *
-     * @deprecated v3.6
+     * @deprecated v3.6.0 - Will be removed in v5.0.0.
+     *
      * @param string $name
      * @return mixed|null
      */
@@ -1253,8 +1253,9 @@ class Web
      * Send the contents of the file to the client browser
      * as raw data.
      *
+     * @deprecated v0.8.5 - Will be removed in v5.0.0.
+     *
      * @param string $filename
-     * @deprecated deprecated since 0.8.5
      */
     public function sendFile($filename)
     {
@@ -1513,7 +1514,8 @@ class Web
      * defined in a model.php inside
      * as module.
      *
-     * @deprecated v3.6
+     * @deprecated v3.6.0 - Will be removed in v5.0.0.
+     *
      * @param string $name
      * @return mixed|null
      */
@@ -2042,9 +2044,7 @@ class Web
     /**
      * Call all PRE ACTION listeners
      *
-     * "pre listeners" should not be used anymore - will be removed in v4
-     *
-     * @deprecated v3.6.13
+     * @deprecated v3.6.13 - Will be removed in v5.0.0, "pre listeners" should not be used anymore.
      */
     public function _callPreListeners()
     {
@@ -2064,9 +2064,7 @@ class Web
      * Call all POST ACTION listeners
      * (rely on listener files included from pre_listener call!
      *
-     * "post listeners" should not be used anymore - will be removed in v4
-     *
-     * @deprecated v3.6.13
+     * @deprecated v3.6.13 - Will be removed in v5.0.0, "post listeners" should not be used anymore.
      */
     public function _callPostListeners()
     {


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [x] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- List your changes as a dot point list. -->
## Changelog
- Deprecated formatMoney() function.
- Added new formatCurrency() function.
- Added unit tests for formatcurrency() function.
- Cleaned up various deprecation comments.
- Added removal version to deprecated functions/methods.

<!-- Add any important refs or issues numbers. -->
refs: 10215