### PR TITLE
fix: from arn merge issue

### DIFF
--- a/system/modules/admin/models/AwsTransport.php
+++ b/system/modules/admin/models/AwsTransport.php
@@ -66,24 +66,20 @@ class AwsTransport implements GenericTransport
 
         $queue_url = Config::get("admin.mail.aws.queue_url");
         if (empty($queue_url)) {
-            LogService::getInstance($this->w)->error("Failed to send mail to: $to, from: $reply_to, about: $subject: admin.mail.aws.queue_url not set in config");
+            LogService::getInstance($this->w)->setLogger("EMAIL")->error("Failed to send mail to: $to, from: $reply_to, about: $subject: admin.mail.aws.queue_url not set in config");
             return;
         }
 
         $from_arn = Config::get("admin.mail.aws.from_arn");
-        if (empty($from_arn)) {
-            LogService::getInstance($this->w)->error("Failed to send mail to: $to, from: $reply_to, about: $subject: admin.mail.aws.from_arn not set in config");
-            return;
-        }
 
         $from = Config::get("main.company_support_email");
         if (empty($from)) {
-            $this->w->Log->error("Failed to send mail to: $to, from: $reply_to, about: $subject: main.company_support_email not set in config");
+            LogService::getInstance($this->w)->setLogger("EMAIL")->error("Failed to send mail to: $to, from: $reply_to, about: $subject: main.company_support_email not set in config");
             return;
         }
 
         if (empty($to) || strlen($to) === 0) {
-            LogService::getInstance($this->w)->error("Failed to send mail to: $to, from: $reply_to, about: $subject: no recipients");
+            LogService::getInstance($this->w)->setLogger("EMAIL")->error("Failed to send mail to: $to, from: $reply_to, about: $subject: no recipients");
             return;
         }
 


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [x] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
I've removed the requirement for ```admin.mail.aws.from_arn``` to be set in the config for emails to send. This isn't required and looks to be some kind of merge issue with an old feature branch.

<!-- List your changes as a dot point list. -->
## Changelog
- Removed the requirement for admin.mail.aws.from_arn to be set in the config.
- Replaced usage of methods method with getInstance() singleton.
- Added setLogger call to error logs.

<!-- Add any important refs or issues numbers. -->
refs: 10211