### PR TITLE
fix: pdo is array check

### DIFF
--- a/system/classes/DbPDO.php
+++ b/system/classes/DbPDO.php
@@ -357,7 +357,8 @@ class DbPDO extends PDO
             return null;
         }
 
-        return (!is_null($row[$element]) ? $row[$element] : null);
+        // Check that $row is an array DbPdo::fetchRow() will return false on failure.
+        return (is_array($row) ? $row[$element] : null);
     }
 
     /**

--- a/system/modules/auth/models/User.php
+++ b/system/modules/auth/models/User.php
@@ -375,7 +375,7 @@ class User extends DbObject
                     return true;
                 }
             } else {
-                $this->w->Log->error("Role '" . $rn . "' does not exist!");
+                LogService::getInstance($this->w)->setLogger("AUTH")->error("Role '$rn' does not exist!");
             }
         }
 


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [x] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
The underlying call to [PDO::query()](https://www.php.net/manual/en/pdo.query.php) return false on failure. I've updated the check from ```!is_null()``` to ```is_array()``` so the index operator isn't used on a boolean.

<!-- List your changes as a dot point list. -->
## Changelog
- Updated the result from DbPdo::fetchRow() inside DbPdo::fetchElement() to be is_array not is_null.
- Cleaned up Log call.

<!-- Add any important refs or issues numbers. -->
refs: 10353