### PR TITLE
feat: config set from s3

### DIFF
--- a/system/config.php
+++ b/system/config.php
@@ -82,3 +82,11 @@ Config::set("system.ldap", [
     'auth_search'   => '(cn={$username})', // {username} will be replaced in auth
     'search_filter_attribute' => [], // Here you can specify only certain attributes to get from ldap such as "ou" or "cn" etc
 ]);
+
+Config::set('system.aws', [
+    // Only used when system.environment is set to 'development'.
+    'credentials' => [
+        'key' => '',
+        'secret' => '',
+    ],
+]);

--- a/system/modules/main/config.php
+++ b/system/modules/main/config.php
@@ -69,5 +69,5 @@ Config::set('main', [
             '/system/templates/vue-components/loading-indicator.vue.js',
             '/system/templates/vue-components/loading-indicator.vue.css'
         ],
-    ]
+    ],
 ]);


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [x] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- List your changes as a dot point list. -->
## Changelog
- Added the ability to set config items from an object in S3.

<!-- Add any important refs or issues numbers. -->
refs: 10394