### PR TITLE
fix: Auth Page By Https

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop, master ]
+    branches: [ develop, master, legacy/PHP7.2 ]
 
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: '2pisoftware/cmfive-boilerplate'
-          ref: 'feature/cicd'
+          ref: 'legacy/PHP7.2'
 
       - name: Cache composer output
         uses: actions/cache@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop, master, legacy/PHP7.2 ]
+    branches: [ develop, master ]
 
   workflow_dispatch:
 
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: '2pisoftware/cmfive-boilerplate'
-          ref: 'legacy/PHP7.2'
+          ref: 'feature/cicd'
 
       - name: Cache composer output
         uses: actions/cache@v2

--- a/system/modules/auth/actions/forgotpassword.php
+++ b/system/modules/auth/actions/forgotpassword.php
@@ -40,7 +40,7 @@ function forgotpassword_POST(Web $w)
     // Send email
     $message = "Hello {$user->getFullName()},\n<br/>";
     $message .= "Please go to this link to reset your password:<br/>\n";
-    $message .= "<a href=\"http://" . $_SERVER["HTTP_HOST"] . "/auth/resetpassword?email={$user_contact->email}&token={$user->password_reset_token}\">http://"
+    $message .= "<a href=\"https://" . $_SERVER["HTTP_HOST"] . "/auth/resetpassword?email={$user_contact->email}&token={$user->password_reset_token}\">https://"
         . $_SERVER["HTTP_HOST"] . "/auth/resetpassword?token={$user->password_reset_token}</a>\n<br/>You have 24 hours to reset your password.<br/><br/>";
     $message .= "Thank you,\n<br/>cmfive support";
 


### PR DESCRIPTION
Regression of intended 7.4 change onto 7.2:
ci/cd methods promise ssl available to test environments
 = no reason for auth/forgot password to reference http://

refs: 10407

## Checklist
- [y] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [y] I've added comments to any new methods I've created or where else relevant.
- [y] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [y] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

## Description

## Changelog

refs: 10407
issues:

## Other Information

Docs pull request: