### PR TITLE
fix: large attachment downloads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop, master ]
+    branches: [ develop, master, legacy/PHP7.2 ]
 
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: '2pisoftware/cmfive-boilerplate'
-          ref: 'feature/cicd'
+          ref: 'legacy/PHP7.2'
 
       - name: Cache composer output
         uses: actions/cache@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ develop ]
   pull_request:
-    branches: [ develop, master, legacy/PHP7.2 ]
+    branches: [ develop, master ]
 
   workflow_dispatch:
 
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: '2pisoftware/cmfive-boilerplate'
-          ref: 'legacy/PHP7.2'
+          ref: 'feature/cicd'
 
       - name: Cache composer output
         uses: actions/cache@v2

--- a/system/modules/file/actions/atdownload.php
+++ b/system/modules/file/actions/atdownload.php
@@ -1,0 +1,17 @@
+<?php
+function atdownload_GET(Web &$w)
+{
+    list($id) = $w->pathMatch();
+
+    $attachment = FileService::getInstance($w)->getAttachment($id);
+    if (!empty($attachment) && $attachment->exists()) {
+        //check if no user logged in, is attachment public
+        if (!AuthService::getInstance($w)->loggedIn() && !($attachment->is_public || $attachment->checkViewingWindow())) {
+            return;
+        }
+        $attachment->writeOut();
+    } else {
+        $w->header("HTTP/1.1 404 Not Found");
+        $w->notFoundPage();
+    }
+}

--- a/system/modules/file/file.roles.php
+++ b/system/modules/file/file.roles.php
@@ -28,5 +28,6 @@ function role_file_download_allowed(Web $w,$path) {
 			$w->checkUrl($path, "file", null, "atdel") ||
 			$w->checkUrl($path, "file", null, "printview") ||
 			$w->checkUrl($path, "file", null, "atfile") ||
+			$w->checkUrl($path, "file", null, "atdownload") ||
 			$w->checkUrl($path, "file", null, "thumb");
 }

--- a/system/modules/file/models/Attachment.php
+++ b/system/modules/file/models/Attachment.php
@@ -339,6 +339,16 @@ class Attachment extends DbObject
     }
 
     /**
+     * Sends header and content of file to browser without intermediaries, via exit(0)=Terminates execution!
+     * @param string $saveAs Override Filename for browser 'save as'
+     * @return void
+     */
+    public function writeOut(?string $saveAs = null): void
+    {
+        FileService::getInstance($this->w)->writeOutAttachment($this, $saveAs);
+    }
+
+    /**
      * Moves the content from one adapter to another
      */
     public function moveToAdapter($adapter = "local", $delete_after_move = false)

--- a/system/modules/file/models/FileService.php
+++ b/system/modules/file/models/FileService.php
@@ -131,6 +131,26 @@ class FileService extends DbService
         return $this->getSpecificFilesystem($this->getActiveAdapter(), $path, $content, $options);
     }
 
+
+    /**
+     * Get core cmfive s3 client, radically below abstraction of Gaufrette Filesystem
+     *
+     * @return S3Client
+     */
+    public function getS3ClientBelowFilesystem()
+    {
+        $args = [
+            "region" =>  Config::get("file.adapters.s3.region", "ap-southeast-2"),
+            "version" => Config::get("file.adapters.s3.version", "2006-03-01"),
+        ];
+
+        if (Config::get("system.environment", ENVIRONMENT_PRODUCTION) === ENVIRONMENT_DEVELOPMENT) {
+            $args["credentials"] = Config::get("file.adapters.s3.credentials");
+        }
+
+        return new Aws\S3\S3Client($args);
+    }
+
     /**
      * Get a Gaufrette Filesystem for a given adapter and path
      *
@@ -152,7 +172,16 @@ class FileService extends DbService
                 $adapter_obj = new InMemoryAdapter([basename($path) => $content]);
                 break;
             case "s3":
-                $client = new Aws\S3\S3Client(Config::get('file.adapters.s3'));
+                // $args = [
+                //     "region" =>  Config::get("file.adapters.s3.region", "ap-southeast-2"),
+                //     "version" => Config::get("file.adapters.s3.version", "2006-03-01"),
+                // ];
+
+                // if (Config::get("system.environment", ENVIRONMENT_PRODUCTION) === ENVIRONMENT_DEVELOPMENT) {
+                //     $args["credentials"] = Config::get("file.adapters.s3.credentials");
+                // }
+
+                $client = $this->getS3ClientBelowFilesystem(); //new Aws\S3\S3Client($args);
                 $config_options = Config::get('file.adapters.s3.options');
                 $s3path = (substr($path, -1) == "/") ? substr($path, 0, -1) : $path; // because trailing presence varies with call/object history
                 $config_options = array_replace(is_array($config_options) ? $config_options : [], ["directory" => $s3path], $options);
@@ -190,7 +219,17 @@ class FileService extends DbService
             case "s3":
                 $config_options = $adapter_config['options'];
                 $config_options = array_replace(is_array($config_options) ? $config_options : [], ["directory" => $path], $options);
-                $client = S3Client::factory(["key" => $adapter_config['key'], "secret" => $adapter_config['secret']]);
+
+                // $args = [
+                //     "region" =>  Config::get("file.adapters.s3.region", "ap-southeast-2"),
+                //     "version" => Config::get("file.adapters.s3.version", "2006-03-01"),
+                // ];
+
+                // if (Config::get("system.environment", ENVIRONMENT_PRODUCTION) === ENVIRONMENT_DEVELOPMENT) {
+                //     $args["credentials"] = Config::get("file.adapters.s3.credentials");
+                // }
+
+                $client = $this->getS3ClientBelowFilesystem(); //new S3Client($args);
                 $adapter_obj = new AwsS3($client, $adapter_config['bucket'], is_array($config_options) ? $config_options : []);
                 break;
         }
@@ -431,43 +470,64 @@ class FileService extends DbService
 
 
     /**
-     * Sends header and content of file to browser without intermediaries, via exit(0)=Terminates execution!
+     * Sends header and content of file to browser without intermediaries:
+     * defaults to via filestream & exit(0)=Terminates execution!
+     * otherwise, for s3, redirects to presigned url
+     * In both cases, allows for largest possible file size by bypassing
+     * PHP memory handling of data
      * @param Attachment $att The Attachment
      * @param string $saveAs Override Filename for browser as string
      * @return void
      */
     public function writeOutAttachment(Attachment $att, ?string $saveAs = null): void
     {
-        $this->w->setLayout(null);
-        // per : https://www.php.net/manual/en/function.readfile.php
-        // readfile() will not present any memory issues on its own.
-        // If you encounter an out of memory error ensure that output buffering is off
-        if (ob_get_level()) {
-            ob_end_clean();
+        switch ($att->adapter) {
+
+            case "s3":
+                $client = $this->getS3ClientBelowFilesystem();
+                $cmd = $client->getCommand('GetObject', [
+                    'Bucket' => Config::get('file.adapters.s3.bucket'),
+                    'Key' => $att->fullpath
+                ]);
+
+                $request = $client->createPresignedRequest($cmd, '+300 minutes');
+
+                // Get the actual presigned-url
+                $this->w->redirect((string)$request->getUri());
+                break;
+
+            default:
+                $this->w->setLayout(null);
+                // per : https://www.php.net/manual/en/function.readfile.php
+                // readfile() will not present any memory issues on its own.
+                // If you encounter an out of memory error ensure that output buffering is off
+                if (ob_get_level()) {
+                    ob_end_clean();
+                }
+                $this->w->header('Content-Description: File Transfer');
+                $this->w->header(
+                    'Content-Type: '
+                        . (empty($att->mimetype) ? "application/octet-stream" : $att->mimetype)
+                );
+                $this->w->header(
+                    'Content-Disposition: attachment; filename="'
+                        . ($saveAs ?? $att->filename) . '"'
+                );
+                $this->w->header('Expires: 0');
+                $this->w->header('Cache-Control: must-revalidate');
+                $this->w->header('Pragma: public');
+
+                $filesystem = $att->getFileSystem();
+
+                $map = StreamWrapper::getFilesystemMap();
+                $map->set('mandated_stream', $filesystem);
+
+                StreamWrapper::register();
+                $streamFrom = 'gaufrette://mandated_stream/' . $att->filename;
+                $this->w->header('Content-Length: ' . filesize($streamFrom));
+                readfile($streamFrom);
+                exit(0);
         }
-        $this->w->header('Content-Description: File Transfer');
-        $this->w->header(
-            'Content-Type: '
-                . (empty($att->mimetype) ? "application/octet-stream" : $att->mimetype)
-        );
-        $this->w->header(
-            'Content-Disposition: attachment; filename="'
-                . ($saveAs ?? $att->filename). '"'
-        );
-        $this->w->header('Expires: 0');
-        $this->w->header('Cache-Control: must-revalidate');
-        $this->w->header('Pragma: public');
-
-        $filesystem = $att->getFileSystem();
-
-        $map = StreamWrapper::getFilesystemMap();
-        $map->set('mandated_stream', $filesystem);
-
-        StreamWrapper::register();
-        $streamFrom = 'gaufrette://mandated_stream/' . $att->filename;
-        $this->w->header('Content-Length: ' . filesize($streamFrom));
-        readfile($streamFrom);
-        exit(0);
     }
 
     /**

--- a/system/modules/file/models/FileService.php
+++ b/system/modules/file/models/FileService.php
@@ -143,10 +143,8 @@ class FileService extends DbService
             "region" =>  Config::get("file.adapters.s3.region", "ap-southeast-2"),
             "version" => Config::get("file.adapters.s3.version", "2006-03-01"),
         ];
-
-        // if (Config::get("system.environment", ENVIRONMENT_PRODUCTION) === ENVIRONMENT_DEVELOPMENT) {
-            $args["credentials"] = Config::get("file.adapters.s3.credentials");
-        // }
+        
+        $args["credentials"] = Config::get("file.adapters.s3.credentials");
 
         return new Aws\S3\S3Client($args);
     }
@@ -172,15 +170,6 @@ class FileService extends DbService
                 $adapter_obj = new InMemoryAdapter([basename($path) => $content]);
                 break;
             case "s3":
-                // $args = [
-                //     "region" =>  Config::get("file.adapters.s3.region", "ap-southeast-2"),
-                //     "version" => Config::get("file.adapters.s3.version", "2006-03-01"),
-                // ];
-
-                // if (Config::get("system.environment", ENVIRONMENT_PRODUCTION) === ENVIRONMENT_DEVELOPMENT) {
-                //     $args["credentials"] = Config::get("file.adapters.s3.credentials");
-                // }
-
                 $client = $this->getS3ClientBelowFilesystem(); //new Aws\S3\S3Client($args);
                 $config_options = Config::get('file.adapters.s3.options');
                 $s3path = (substr($path, -1) == "/") ? substr($path, 0, -1) : $path; // because trailing presence varies with call/object history
@@ -219,15 +208,6 @@ class FileService extends DbService
             case "s3":
                 $config_options = $adapter_config['options'];
                 $config_options = array_replace(is_array($config_options) ? $config_options : [], ["directory" => $path], $options);
-
-                // $args = [
-                //     "region" =>  Config::get("file.adapters.s3.region", "ap-southeast-2"),
-                //     "version" => Config::get("file.adapters.s3.version", "2006-03-01"),
-                // ];
-
-                // if (Config::get("system.environment", ENVIRONMENT_PRODUCTION) === ENVIRONMENT_DEVELOPMENT) {
-                //     $args["credentials"] = Config::get("file.adapters.s3.credentials");
-                // }
 
                 $client = $this->getS3ClientBelowFilesystem(); //new S3Client($args);
                 $adapter_obj = new AwsS3($client, $adapter_config['bucket'], is_array($config_options) ? $config_options : []);

--- a/system/modules/file/models/FileService.php
+++ b/system/modules/file/models/FileService.php
@@ -144,9 +144,9 @@ class FileService extends DbService
             "version" => Config::get("file.adapters.s3.version", "2006-03-01"),
         ];
 
-        if (Config::get("system.environment", ENVIRONMENT_PRODUCTION) === ENVIRONMENT_DEVELOPMENT) {
+        // if (Config::get("system.environment", ENVIRONMENT_PRODUCTION) === ENVIRONMENT_DEVELOPMENT) {
             $args["credentials"] = Config::get("file.adapters.s3.credentials");
-        }
+        // }
 
         return new Aws\S3\S3Client($args);
     }

--- a/system/modules/file/models/FileService.php
+++ b/system/modules/file/models/FileService.php
@@ -5,6 +5,7 @@ use Gaufrette\File as File;
 use Gaufrette\Adapter\Local as LocalAdapter;
 use Gaufrette\Adapter\InMemory as InMemoryAdapter;
 use Gaufrette\Adapter\AwsS3 as AwsS3;
+use Gaufrette\StreamWrapper as StreamWrapper;
 use Aws\S3\S3Client as S3Client;
 
 /**
@@ -348,7 +349,7 @@ class FileService extends DbService
      *
      * @return array[Attachment]
      */
-    public function getAttachments($object_or_table, $id = null, ?int $page = null, ?int $page_size = null) : array
+    public function getAttachments($object_or_table, $id = null, ?int $page = null, ?int $page_size = null): array
     {
         $table = "";
 
@@ -426,6 +427,47 @@ class FileService extends DbService
     public function getAttachment($id)
     {
         return $this->getObject("Attachment", $id);
+    }
+
+
+    /**
+     * Sends header and content of file to browser without intermediaries, via exit(0)=Terminates execution!
+     * @param Attachment $att The Attachment
+     * @param string $saveAs Override Filename for browser as string
+     * @return void
+     */
+    public function writeOutAttachment(Attachment $att, ?string $saveAs = null): void
+    {
+        $this->w->setLayout(null);
+        // per : https://www.php.net/manual/en/function.readfile.php
+        // readfile() will not present any memory issues on its own.
+        // If you encounter an out of memory error ensure that output buffering is off
+        if (ob_get_level()) {
+            ob_end_clean();
+        }
+        $this->w->header('Content-Description: File Transfer');
+        $this->w->header(
+            'Content-Type: '
+                . (empty($att->mimetype) ? "application/octet-stream" : $att->mimetype)
+        );
+        $this->w->header(
+            'Content-Disposition: attachment; filename="'
+                . ($saveAs ?? $att->filename). '"'
+        );
+        $this->w->header('Expires: 0');
+        $this->w->header('Cache-Control: must-revalidate');
+        $this->w->header('Pragma: public');
+
+        $filesystem = $att->getFileSystem();
+
+        $map = StreamWrapper::getFilesystemMap();
+        $map->set('mandated_stream', $filesystem);
+
+        StreamWrapper::register();
+        $streamFrom = 'gaufrette://mandated_stream/' . $att->filename;
+        $this->w->header('Content-Length: ' . filesize($streamFrom));
+        readfile($streamFrom);
+        exit(0);
     }
 
     /**
@@ -664,7 +706,7 @@ class FileService extends DbService
      *
      * @return string
      */
-    public static function getCacheRuntimePath() : string
+    public static function getCacheRuntimePath(): string
     {
         if (self::$cache_runtime_path === null) {
             self::$cache_runtime_path = uniqid();


### PR DESCRIPTION
Hotfix/large attachment downloads

## Checklist
- [y] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [y] I've added comments to any new methods I've created or where else relevant.
- [?] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [?] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

## Description
s3 presigning as in use for large file requirements on client proof site

## Changelog

refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: