### PR TITLE
feat: request has method

### DIFF
--- a/system/classes/Request.php
+++ b/system/classes/Request.php
@@ -101,7 +101,7 @@ class Request
      * @param string ...$keys
      * @return boolean
      */
-    public static function has(string ...$keys): bool
+    public static function hasAny(string ...$keys): bool
     {
         foreach ($keys as $key) {
             if (array_key_exists($key, $_REQUEST)) {

--- a/system/classes/Request.php
+++ b/system/classes/Request.php
@@ -96,6 +96,17 @@ class Request
     }
 
     /**
+     * Checks if the $key parameter exists in the $_REQUEST superglobal.
+     *
+     * @param string $key
+     * @return boolean
+     */
+    public static function has(string $key): bool
+    {
+        return array_key_exists($key, $_REQUEST);
+    }
+
+    /**
      * Checks if any of the keys in the $keys parameter exists in the $_REQUEST superglobal.
      *
      * @param string ...$keys
@@ -110,5 +121,22 @@ class Request
         }
 
         return false;
+    }
+
+    /**
+     * Checks if all of the keys in the $keys parameter exist in the $_REQUEST superglobal.
+     *
+     * @param string ...$keys
+     * @return boolean
+     */
+    public static function hasAll(string ...$keys): bool
+    {
+        foreach ($keys as $key) {
+            if (!array_key_exists($key, $_REQUEST)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/system/classes/Request.php
+++ b/system/classes/Request.php
@@ -94,4 +94,21 @@ class Request
 
         return is_string($_REQUEST[$key]) ? trim($_REQUEST[$key]) : $_REQUEST[$key];
     }
+
+    /**
+     * Checks if any of the keys in the $keys parameter exists in the $_REQUEST superglobal.
+     *
+     * @param string ...$keys
+     * @return boolean
+     */
+    public static function has(string ...$keys): bool
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $_REQUEST)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/system/modules/admin/actions/useradd.php
+++ b/system/modules/admin/actions/useradd.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Display User edit form in colorbox
  *
@@ -8,11 +9,11 @@ function useradd_GET(Web &$w) {
 	$p = $w->pathMatch("box");
 	$w->ctx('availableLocales', $w->getAvailableLanguages());
 
-	if (!$p['box']) {
-		$w->Admin->navigation($w, "Add User");
-	} else {
-		$w->setLayout(null);
-	}
+    if (!$p['box']) {
+        $w->Admin->navigation($w, "Add User");
+    } else {
+        $w->setLayout(null);
+    }
 }
 
 /**
@@ -20,51 +21,52 @@ function useradd_GET(Web &$w) {
  *
  * @param <type> $w
  */
-function useradd_POST(Web &$w) {
-	$errors = $w->validate(array(
-		array("login", ".+", "Login is mandatory"),
-		array("password", ".+", "Password is mandatory"),
-		array("password2", ".+", "Password2 is mandatory"),
-	));
-	if ($_REQUEST['password2'] != $_REQUEST['password']) {
-		$errors[] = "Passwords don't match";
-	}
-	if (sizeof($errors) != 0) {
-		$w->error(implode("<br/>\n", $errors), "/admin/useradd");
-	}
+function useradd_POST(Web &$w)
+{
+    $errors = $w->validate([
+        ["login", ".+", "Login is mandatory"],
+        ["password", ".+", "Password is mandatory"],
+        ["password2", ".+", "Password2 is mandatory"],
+    ]);
+    if ($_REQUEST['password2'] != $_REQUEST['password']) {
+        $errors[] = "Passwords don't match";
+    }
+    if (sizeof($errors) != 0) {
+        $w->error(implode("<br/>\n", $errors), "/admin/useradd");
+    }
 
-	// first saving basic contact info
-	$contact = new Contact($w);
-	$contact->fill($_REQUEST);
-	$contact->dt_created = time();
-	$contact->private_to_user_id = null;
-	$contact->setTitle($_REQUEST['acp_title']);
-	$contact->insert();
+    // first saving basic contact info
+    $contact = new Contact($w);
+    $contact->fill($_REQUEST);
+    $contact->dt_created = time();
+    $contact->private_to_user_id = null;
+    $contact->setTitle($_REQUEST['acp_title']);
+    $contact->insert();
 
-	// now saving the user
-	$user = new User($w);
-	$user->login = $_REQUEST['login'];
-	$user->language = $_REQUEST['language'];
-	$user->is_active = !empty($_REQUEST['is_active']) ? $_REQUEST['is_active'] : 0;
-	$user->is_admin = !empty($_REQUEST['is_admin']) ? $_REQUEST['is_admin'] : 0;
-	$user->is_group = 0;
+    // now saving the user
+    $user = new User($w);
+    $user->login = $_REQUEST['login'];
+    $user->language = $_REQUEST['language'];
+    $user->is_active = !empty($_REQUEST['is_active']) ? $_REQUEST['is_active'] : 0;
+    $user->is_admin = !empty($_REQUEST['is_admin']) ? $_REQUEST['is_admin'] : 0;
+    $user->is_group = 0;
     $user->is_external = isset($_REQUEST['is_external']) ? 1 : 0;
-	$user->dt_created = time();
-	$user->contact_id = $contact->id;
-	$user->setPassword($_REQUEST['password'], false);
-	$user->insert();
-	$w->ctx("user", $user);
+    $user->dt_created = time();
+    $user->contact_id = $contact->id;
+    $user->setPassword($_REQUEST['password'], false);
+    $user->insert();
+    $w->ctx("user", $user);
 
-	// now saving the roles
-	$roles = $w->Auth->getAllRoles();
-	foreach ($roles as $r) {
-		if (!empty($_REQUEST["check_" . $r])) {
-			if ($_REQUEST["check_" . $r] == 1) {
-				$user->addRole($r);
-			}
-		}
-	}
-	$w->callHook("admin", "account_changed", $user);
+    // now saving the roles
+    $roles = $w->Auth->getAllRoles();
+    foreach ($roles as $r) {
+        if (!empty($_REQUEST["check_" . $r])) {
+            if ($_REQUEST["check_" . $r] == 1) {
+                $user->addRole($r);
+            }
+        }
+    }
+    $w->callHook("admin", "account_changed", $user);
 
-	$w->msg("<div id='saved_record_id' data-id='" . $user->id . "' >User " . $user->login . " added</div>", "/admin/users");
+    $w->msg("<div id='saved_record_id' data-id='" . $user->id . "' >User " . $user->login . " added</div>", "/admin/users");
 }

--- a/system/modules/admin/models/AuditService.php
+++ b/system/modules/admin/models/AuditService.php
@@ -21,8 +21,7 @@ class AuditService extends DbService
         // is in the list
         if ($blacklist) {
             foreach ($blacklist as $line) {
-                if (
-                    $line[0] == $this->w->currentModule() &&
+                if ($line[0] == $this->w->currentModule() &&
                     ($line[1] == $this->w->currentAction() || $line[1] == "*")
                 ) {
                     return;
@@ -56,7 +55,7 @@ class AuditService extends DbService
 
     public function getLoggedUsers()
     {
-        $ids = $this->_db->sql("select distinct creator_id from audit")->fetch_all();
+        $ids = $this->_db->sql("select distinct creator_id from audit")->fetchAll();
         $users = [];
         foreach ($ids as $id) {
             $users[] = $this->getObject("User", $id["creator_id"]);
@@ -66,7 +65,7 @@ class AuditService extends DbService
 
     public function getLoggedModules()
     {
-        $modules = $this->_db->sql("select distinct module from audit order by module")->fetch_all();
+        $modules = $this->_db->sql("select distinct module from audit order by module")->fetchAll();
         foreach ($modules as $m) {
             $list[] = $m['module'];
         }
@@ -75,7 +74,7 @@ class AuditService extends DbService
 
     public function getLoggedActions()
     {
-        $actions = $this->_db->sql("select distinct action from audit order by action")->fetch_all();
+        $actions = $this->_db->sql("select distinct action from audit order by action")->fetchAll();
         foreach ($actions as $m) {
             $list[] = $m['action'];
         }
@@ -94,7 +93,7 @@ class AuditService extends DbService
     {
         $users = [];
         $stmt = "SELECT distinct creator_id FROM audit where timediff(now(), dt_created) < " . $this->_db->quote("00:" . $idleMinutes  . ":00") . " and creator_id > 0";
-        $res = $this->_db->sql($stmt)->fetch_all();
+        $res = $this->_db->sql($stmt)->fetchAll();
         if ($res && sizeof($res)) {
             foreach ($res as $row) {
                 $users[] = $this->getObject("User", $row['creator_id']);
@@ -103,7 +102,7 @@ class AuditService extends DbService
         return $users;
     }
 
-    
+
     public function getAudits($dt_from = null, $dt_to = null, $user_id = null, $module = null, $action = null)
     {
         //build where array

--- a/system/modules/auth/actions/forgotpassword.php
+++ b/system/modules/auth/actions/forgotpassword.php
@@ -19,8 +19,7 @@ function forgotpassword_POST(Web $w)
         $w->error("Cannot send recovery email. This site has not been configured with a default email address", "/auth/login");
     }
 
-    $login = $w->request("login");
-    $user = AuthService::getInstance($w)->getUserForLogin($login);
+    $user = AuthService::getInstance($w)->getUserForLogin(Request::string('login'));
     $responseString = "If this account exists then a password reset email has been just sent to the associated email address.";
 
     // For someone trying to gain access to a system, this is one of the

--- a/system/modules/auth/models/User.php
+++ b/system/modules/auth/models/User.php
@@ -433,7 +433,7 @@ class User extends DbObject
      * not.
      *
      * @param string $password
-     * @param boolean $update_salt - DEPRICATED
+     * @param boolean $update_salt - Deprecated, will be removed in v5.0.0.
      */
     public function setPassword($password, $update_salt = true)
     {

--- a/system/modules/main/tests/unit/RequestTest.php
+++ b/system/modules/main/tests/unit/RequestTest.php
@@ -166,4 +166,30 @@ class RequestTest extends TestCase
         // Test that a default value is returned when that key doesn't exist.
         $this->assertEquals(2, Request::mixed("test-mixed-default", 2));
     }
+
+    /**
+     * Test Request::has().
+     *
+     * @return void
+     */
+    public function testHas(): void
+    {
+        require_once("system/web.php");
+        $w = new Web();
+
+        // Test that a single key is not found when it doesn't exist.
+        $this->assertEquals(false, Request::has("key-1"));
+        // Test that multiple keys aren't found when they don't exist.
+        $this->assertEquals(false, Request::has("key-1", "key-2", "key-3"));
+
+        // Test that a single key is found when it does exist.
+        $_REQUEST["key-1"] = "value-1";
+        $this->assertEquals(true, Request::has("key-1"));
+
+        // Test that any of these keys are found when some exist and some don't.
+        unset($_REQUEST["key-1"]);
+        $_REQUEST["key-2"] = "value-1";
+        $_REQUEST["key-3"] = "value-1";
+        $this->assertEquals(true, Request::has("key-1", "key-2", "key-3"));
+    }
 }

--- a/system/modules/main/tests/unit/RequestTest.php
+++ b/system/modules/main/tests/unit/RequestTest.php
@@ -168,6 +168,24 @@ class RequestTest extends TestCase
     }
 
     /**
+     * Test Reqest::has().
+     *
+     * @return void
+     */
+    public function testHas(): void
+    {
+        require_once("system/web.php");
+        $w = new Web();
+
+        // Test that a key is not found when it doesn't exist.
+        $this->assertEquals(false, Request::has("key-1"));
+
+        // Test that a key is found when it does exist.
+        $_REQUEST["key-1"] = "value-1";
+        $this->assertEquals(true, Request::has("key-1"));
+    }
+
+    /**
      * Test Request::hasAny().
      *
      * @return void
@@ -191,5 +209,30 @@ class RequestTest extends TestCase
         $_REQUEST["key-2"] = "value-1";
         $_REQUEST["key-3"] = "value-1";
         $this->assertEquals(true, Request::hasAny("key-1", "key-2", "key-3"));
+    }
+
+    /**
+     * Test Request::hasAll()
+     *
+     * @return void
+     */
+    public function testHasAll(): void
+    {
+        require_once("system/web.php");
+        $w = new Web();
+
+        // Test that a single key is not found when it doesn't exist.
+        $this->assertEquals(false, Request::hasAll("key-1"));
+        // Test that multiple keys aren't found when they don't exist.
+        $this->assertEquals(false, Request::hasAll("key-1", "key-2", "key-3"));
+
+        // Test that a single key is found when it does exist.
+        $_REQUEST["key-1"] = "value-1";
+        $this->assertEquals(true, Request::hasAll("key-1"));
+
+        // Test that any of these keys are found when some exist and some don't.
+        $_REQUEST["key-2"] = "value-1";
+        $_REQUEST["key-3"] = "value-1";
+        $this->assertEquals(true, Request::hasAll("key-1", "key-2", "key-3"));
     }
 }

--- a/system/modules/main/tests/unit/RequestTest.php
+++ b/system/modules/main/tests/unit/RequestTest.php
@@ -168,28 +168,28 @@ class RequestTest extends TestCase
     }
 
     /**
-     * Test Request::has().
+     * Test Request::hasAny().
      *
      * @return void
      */
-    public function testHas(): void
+    public function testHasAny(): void
     {
         require_once("system/web.php");
         $w = new Web();
 
         // Test that a single key is not found when it doesn't exist.
-        $this->assertEquals(false, Request::has("key-1"));
+        $this->assertEquals(false, Request::hasAny("key-1"));
         // Test that multiple keys aren't found when they don't exist.
-        $this->assertEquals(false, Request::has("key-1", "key-2", "key-3"));
+        $this->assertEquals(false, Request::hasAny("key-1", "key-2", "key-3"));
 
         // Test that a single key is found when it does exist.
         $_REQUEST["key-1"] = "value-1";
-        $this->assertEquals(true, Request::has("key-1"));
+        $this->assertEquals(true, Request::hasAny("key-1"));
 
         // Test that any of these keys are found when some exist and some don't.
         unset($_REQUEST["key-1"]);
         $_REQUEST["key-2"] = "value-1";
         $_REQUEST["key-3"] = "value-1";
-        $this->assertEquals(true, Request::has("key-1", "key-2", "key-3"));
+        $this->assertEquals(true, Request::hasAny("key-1", "key-2", "key-3"));
     }
 }

--- a/system/web.php
+++ b/system/web.php
@@ -2008,6 +2008,9 @@ class Web
      * Returns the request value in a safe way
      * without generating warning.
      *
+     * @deprecated v4.3.0 - Will be removed in v5.0.0.
+     * @see Request class.
+     *
      * @param <type> $key
      * @param <type> $default
      * @return <type>
@@ -2015,12 +2018,10 @@ class Web
     public function request($key, $default = null)
     {
         if (array_key_exists($key, $_REQUEST) && is_array($_REQUEST[$key])) {
-            foreach ($_REQUEST[$key] as &$k) {
-                $k = urldecode($k);
-            }
             return $_REQUEST[$key];
         }
-        return array_key_exists($key, $_REQUEST) ? urldecode($_REQUEST[$key]) : $default;
+
+        return array_key_exists($key, $_REQUEST) ? $_REQUEST[$key] : $default;
     }
 
     public function requestIpAddress()


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [x] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
Probably the largest change in this PR is the deprecation of ```Web::request()```. Now that the new ```Request``` class is in core we should be using it over the old method.

<!-- List your changes as a dot point list. -->
## Changelog
- Added Request::has() method.
- Added Request::hasAny() method.
- Added Request::hasAll() method.
- Added unit test for Request::has() method.
- Added unit test for Request::hasAny() method.
- Added unit test for Request::hasAll() method.
- Ran formatter over several files.
- Replaced usage of deprecated methods.
- Added removal version of v5.0.0 to deprecated method User::setPassword().
- Marked Web::request() as deprecated with a removal version of v5.0.0.