### PR TITLE
fix: hide sensitive image metadata

### DIFF
--- a/system/modules/file/partials/actions/attachment_item.php
+++ b/system/modules/file/partials/actions/attachment_item.php
@@ -7,4 +7,5 @@ function attachment_item_GET(\Web $w, $params)
     $w->ctx("attachment", $params["attachment"]);
     $w->ctx("owner", \RestrictableService::getInstance($w)->getOwner($params["attachment"]));
     $w->ctx("redirect", $params["redirect"]);
+    $w->ctx("image_data_blocked", $params["hide_image_exif"] ?? false);
 }

--- a/system/modules/file/partials/actions/listattachments.php
+++ b/system/modules/file/partials/actions/listattachments.php
@@ -25,7 +25,11 @@ function listattachments(\Web $w, $params)
             $attachment->update();
         }
 
-        $list_items[] = $w->partial("attachment_item", ["attachment" => $attachment, "redirect" => $redirect], "file", "GET");
+        $list_items[] = $w->partial("attachment_item", [
+            "attachment" => $attachment,
+            "redirect" => $redirect,
+            "hide_image_exif" => $params["hide_image_exif"] ?? false,
+        ], "file", "GET");
     }
 
     $w->ctx("list_items", $list_items);

--- a/system/modules/file/partials/templates/attachment_item.tpl.php
+++ b/system/modules/file/partials/templates/attachment_item.tpl.php
@@ -50,7 +50,7 @@
         <div class="column small-12 medium-<?php echo $attachment->isImage() ? '4' : '6'; ?>">
             <a href="/file/atfile/<?php echo $attachment->id; ?>" target="_blank" class="button expand" onclick="$('#attachment_modal_<?php echo $attachment->id; ?>').foundation('reveal', 'close');">Open in new tab</a>
         </div>
-        <?php if ($attachment->isImage()) { ?>
+        <?php if ($attachment->isImage() && !$image_data_blocked) { ?>
             <div class="column small-12 medium-4">
                 <a href="/file-image/metadata/<?php echo $attachment->id; ?>" target="_blank" class="button expand" onclick="$('#attachment_modal_<?php echo $attachment->id; ?>').foundation('reveal', 'close');">View metadata</a>
             </div>


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [Y ] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [n/a ] I've added comments to any new methods I've created or where else relevant.
- [n/a ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [n/a ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

Sensitive users need to hide metadata
Must be possible to hide exif/metadata link on attachment view.
Use cases exist where exif is over-generous of personal data to be appropriate in cmfive UI.

## Changelog
Added hide exif flag (and default=false) to attachment partials.

refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: