### PR TITLE
fix: bugs on attachment partials

### DIFF
--- a/system/modules/file/partials/actions/attachment_item.php
+++ b/system/modules/file/partials/actions/attachment_item.php
@@ -8,4 +8,5 @@ function attachment_item_GET(\Web $w, $params)
     $w->ctx("owner", \RestrictableService::getInstance($w)->getOwner($params["attachment"]));
     $w->ctx("redirect", $params["redirect"]);
     $w->ctx("image_data_blocked", $params["hide_image_exif"] ?? false);
+    $w->ctx("is_mutable", $params["is_mutable"] ?? true);
 }

--- a/system/modules/file/partials/actions/listattachments.php
+++ b/system/modules/file/partials/actions/listattachments.php
@@ -7,7 +7,7 @@ function listattachments(\Web $w, $params)
     $object = $params["object"];
     $redirect = $params["redirect"];
 
-    $page = $w->sessionOrRequest("attachment__{$object->id}__page", 1);
+    $page = $w->sessionOrRequest("attachment__" . hash("crc32", get_class($object) . $object->id) . "__page", 1);
     $page_size = 6;
     $w->ctx("page", $page);
     $w->ctx("page_size", $page_size);
@@ -29,6 +29,7 @@ function listattachments(\Web $w, $params)
             "attachment" => $attachment,
             "redirect" => $redirect,
             "hide_image_exif" => $params["hide_image_exif"] ?? false,
+            "is_mutable" => $params["is_mutable"] ?? true,
         ], "file", "GET");
     }
 

--- a/system/modules/file/partials/templates/attachment_item.tpl.php
+++ b/system/modules/file/partials/templates/attachment_item.tpl.php
@@ -6,10 +6,14 @@
             </button>
         </div>
         <div class="row-fluid">
-            <?php echo Html::box("/file/edit/" . $attachment->id . "?redirect_url=" . urlencode($redirect), "Edit", true, null, null, null, null, null, "button expand secondary"); ?>
+            <?php echo ($is_mutable)
+                ? (Html::box("/file/edit/" . $attachment->id . "?redirect_url=" . urlencode($redirect), "Edit", true, null, null, null, null, null, "button expand secondary"))
+                : ""; ?>
         </div>
         <div class="row-fluid">
-            <?php echo Html::b("/file/delete/" . $attachment->id . "?redirect_url=" . urlencode($redirect), "Delete", "Are you sure you want to delete this attachment?", null, false, "expand alert "); ?>
+            <?php echo ($is_mutable)
+                ? (Html::b("/file/delete/" . $attachment->id . "?redirect_url=" . urlencode($redirect), "Delete", "Are you sure you want to delete this attachment?", null, false, "expand alert "))
+                : ""; ?>
         </div>
     </div>
     <?php if ($attachment->isImage()) { ?>
@@ -21,10 +25,10 @@
     <?php } ?>
 </div>
 <a href="#" data-reveal-id="attachment_modal_<?php echo $attachment->id; ?>">
-    <div class="row-fluid clearfix text-center">
+    <div class="row-fluid clearfix text-center" style="overflow: hidden;">
         <b>Title: </b><?php echo $attachment->title; ?>
     </div>
-    <div class="row-fluid clearfix text-center">
+    <div class="row-fluid clearfix text-center" style="overflow: hidden;">
         <b>Description: </b><?php echo strip_tags($attachment->description); ?>
     </div>
     <div class="row-fluid clearfix text-center">
@@ -44,7 +48,7 @@
             <i class="fi-page" style="font-size: 90pt;"></i>
         <?php } ?>
     </div>
-    <h2 id="firstModalTitle" style="font-weight: lighter; text-align: center; border-bottom: 1px solid #777;"><?php echo $attachment->title; ?></h2>
+    <h2 id="firstModalTitle" style="overflow-wrap: anywhere; font-weight: lighter; text-align: center; border-bottom: 1px solid #777;"><?php echo $attachment->title; ?></h2>
     <p style="text-align: center;"><?php echo $attachment->description; ?></p>
     <div class="row-fluid">
         <div class="column small-12 medium-<?php echo $attachment->isImage() ? '4' : '6'; ?>">

--- a/system/modules/file/partials/templates/listattachments.tpl.php
+++ b/system/modules/file/partials/templates/listattachments.tpl.php
@@ -13,7 +13,7 @@ if (AuthService::getInstance($w)->user()->hasRole("file_upload")) {
         $redirect,
         null,
         "asc",
-        "attachment__{$object->id}__page",
+        "attachment__" . hash("crc32", get_class($object) . $object->id) . "__page",
         "attachment__page-size"
     ); ?>
 </div>
@@ -54,7 +54,7 @@ if (AuthService::getInstance($w)->user()->hasRole("file_upload")) {
         padding: 10px;
     }
 
-    div.image-container-overlay > .row-fluid {
+    div.image-container-overlay>.row-fluid {
         height: 75px;
     }
 


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [Y] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [n/a] I've added comments to any new methods I've created or where else relevant.
- [n/a] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [n/a] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
SSWP use cases revealing shortcomings:
 - non-unique pagination id's, locking tabbed display
 - spaghetti text from captions not truncating/wrapping
 - edit/delete options not appropriate in use case

<!-- List your changes as a dot point list. -->
CHANGES:
Pagination:
 - ensure uniquness of multiple paginators, for coincident objectId's
 - replace $object->id with short hash of className+objectId
Captioning:
 - truncate text on thumbnail views (inlined style)
 - wrap text on modal file view (inline style)
Mutability:
 - allow partial call to suppress [delete] & [edit] buttons of thumbnails
 - added "is_mutable" param/flag --> default = true
 - cascade new param from listAttachments to attachmentItem

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
Changes required for acceptable presentation on SSWP / cloud uploader

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: