### PR TITLE
fix: Crudely Supress admin cache metric

### DIFF
--- a/system/modules/admin/actions/maintenance/index.php
+++ b/system/modules/admin/actions/maintenance/index.php
@@ -20,7 +20,7 @@ function index_GET(Web $w)
     $w->ctx('audit_row_count', $w->db->get('audit')->count());
 
     if (Config::get('file.adapters.local.active') !== true) {
-        $w->ctx('cache_image_count', FileService::getInstance($w)->countFilesInDirectory(WEBROOT . '/cache'));
+        // $w->ctx('cache_image_count', FileService::getInstance($w)->countFilesInDirectory(WEBROOT . '/cache'));
     }
 
     $w->ctx("number_of_printers", 0);


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [Y ] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [n/a ] I've added comments to any new methods I've created or where else relevant.
- [n/a ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [n/a ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
Mimic interim fix per pending patch from 'new designs'

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: