### PR TITLE
Arbitrary version cap  to prevent PHP8.2 required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: '2pisoftware/cmfive-boilerplate'
-          ref: 'hotfix/FixDockerUbuntuVersion'
+          ref: 'master'
 
       # Cache
       - name: Cache Python Virtual Environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: '2pisoftware/cmfive-boilerplate'
-          ref: 'master'
+          ref: 'hotfix/FixDockerUbuntuVersion'
 
       # Cache
       - name: Cache Python Virtual Environment

--- a/system/modules/admin/config.php
+++ b/system/modules/admin/config.php
@@ -30,7 +30,7 @@ Config::set('admin', [
         "sendgrid/sendgrid" => "~5.5",
         "softark/creole" => "~1.2",
         "monolog/monolog" => "^1.22",
-        "aws/aws-sdk-php" => "^3.24",
+        "aws/aws-sdk-php" => "3.224",
         "aws/aws-php-sns-message-validator" => "^1.1",
         "maxbanton/cwh" => "^1.0"
     ],

--- a/system/modules/file/config.php
+++ b/system/modules/file/config.php
@@ -7,7 +7,7 @@ Config::set('file', [
     'topmenu' => false,
     "dependencies" => [
         "knplabs/gaufrette" => "~0.8",
-        "aws/aws-sdk-php" => "~3.69"
+        "aws/aws-sdk-php" => "3.224"
     ],
     'hooks' => [
         'admin',


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [Y ] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
Arbitrary version cap to prevent PHP8.2 being forced by AWS_SDK->Guzzle->Symfony

<!-- List your changes as a dot point list. -->
## Changelog
Cap the 'required' version in config.php of system/modules/admin & system/modules/file :
        "aws/aws-sdk-php" => "3.224",

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: