### PR TITLE
Feature/php8warnings

### DIFF
--- a/system/html.php
+++ b/system/html.php
@@ -1323,7 +1323,7 @@ class Html
             $title = !empty($row[0]) ? $row[0] : null;
             $type = !empty($row[1]) ? $row[1] : null;
             $name = !empty($row[2]) ? $row[2] : null;
-            $value = !empty($row[3]) ? $row[3] : null;
+            $value = !empty($row[3]) ? $row[3] : " ";
 
             $readonly = "";
 

--- a/system/html.php
+++ b/system/html.php
@@ -637,10 +637,10 @@ class Html
                         continue;
                     }
 
-                    $title = !empty($field[0]) ? $field[0] : null;
-                    $type = !empty($field[1]) ? $field[1] : null;
-                    $name = !empty($field[2]) ? $field[2] : null;
-                    $value = !empty($field[3]) ? $field[3] : null;
+                    $title = !empty($field[0]) ? $field[0] : "";
+                    $type = !empty($field[1]) ? $field[1] : "";
+                    $name = !empty($field[2]) ? $field[2] : "";
+                    $value = !empty($field[3]) ? $field[3] : "";
 
                     // Exploit HTML5s inbuilt form validation
                     $required = null;
@@ -1322,8 +1322,8 @@ class Html
             // Get row parameters
             $title = !empty($row[0]) ? $row[0] : null;
             $type = !empty($row[1]) ? $row[1] : null;
-            $name = !empty($row[2]) ? $row[2] : null;
-            $value = !empty($row[3]) ? $row[3] : " ";
+            $name = !empty($row[2]) ? $row[2] : "";
+            $value = !empty($row[3]) ? $row[3] : "";
 
             $readonly = "";
 

--- a/system/html.php
+++ b/system/html.php
@@ -174,7 +174,7 @@ class Html
     /**
      * Create an a link styled as a button
      * */
-    public static function ab($href, $title, $class = null, $id = null, $confirm = null)
+    public static function ab($href, $title, $class = "", $id = "", $confirm = "")
     {
         $classParam = ' button tiny ';
         if (strlen($class) > 0) {


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [x] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
Fixing warnings for string methods no longer supporting null. 


<!-- List your changes as a dot point list. -->
Fixing warnings for string methods no longer supporting null. 

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: