### PR TITLE
Fix: Stable File Migration

### DIFF
--- a/system/modules/file/actions/admin/moveToAdapter.php
+++ b/system/modules/file/actions/admin/moveToAdapter.php
@@ -7,7 +7,7 @@ function moveToAdapter_GET(Web $w)
     $max_count = Request::string('max_count');
 
     if (empty($max_count)) {
-        $max_count = 1500;
+        $max_count = -1;
     }
 
     if (!empty(Config::get('file.adapters.' . $to_adapter)) && Config::get('file.adapters.' . $to_adapter . '.active') === true) {
@@ -21,15 +21,15 @@ function moveToAdapter_GET(Web $w)
         $attachments = FileService::getInstance($w)->getAttachmentsForAdapter($from_adapter);
         if (!empty($attachments)) {
             foreach ($attachments as $attachment) {
+                if ($max_count >= 0 && $count >= $max_count) {
+                    break;
+                }
                 try {
                     $attachment->moveToAdapter($to_adapter);
                     $count++;
                 } catch (Exception $e) {
                     LogService::getInstance($w)->error($e->getMessage());
                     $skipped++;
-                }
-                if ($count > $max_count) {
-                    break;
                 }
             }
         }

--- a/system/modules/file/actions/admin/moveToAdapter.php
+++ b/system/modules/file/actions/admin/moveToAdapter.php
@@ -4,6 +4,11 @@ function moveToAdapter_GET(Web $w)
 {
     $from_adapter = Request::string('from_adapter');
     $to_adapter = Request::string('to_adapter');
+    $max_count = Request::string('max_count');
+
+    if (empty($max_count)) {
+        $max_count = 1500;
+    }
 
     if (!empty(Config::get('file.adapters.' . $to_adapter)) && Config::get('file.adapters.' . $to_adapter . '.active') === true) {
         if (empty(Config::get('file.adapters.' . $from_adapter))) {
@@ -12,14 +17,27 @@ function moveToAdapter_GET(Web $w)
 
         // From index
         $count = 0;
+        $skipped = 0;
         $attachments = FileService::getInstance($w)->getAttachmentsForAdapter($from_adapter);
         if (!empty($attachments)) {
             foreach ($attachments as $attachment) {
-                $attachment->moveToAdapter($to_adapter);
-                $count++;
+                try {
+                    $attachment->moveToAdapter($to_adapter);
+                    $count++;
+                } catch (Exception $e) {
+                    LogService::getInstance($w)->error($e->getMessage());
+                    $skipped++;
+                }
+                if ($count > $max_count) {
+                    break;
+                }
             }
         }
-        $w->msg($count . ' attachment' . ($count == 1 ? '' : 's') . ' moved from "' . $from_adapter . '" to "' . $to_adapter . '"', '/file-admin');
+        $message = ($count . ' attachment' . ($count == 1 ? '' : 's') . ' moved from "' . $from_adapter . '" to "' . $to_adapter . '"');
+        if ($skipped > 0) {
+            $message = $message . ('<br>' . $skipped . ' attachment' . ($skipped == 1 ? '' : 's') . ' skipped, check logs.');
+        }
+        $w->msg($message, '/file-admin');
     } else {
         $w->error('Target adapter "' . $to_adapter . '" is either not found or not active', '/file-admin');
     }


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [ ] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
Help stop large volume migrations choking on traffic exceptions:
 - Apply outer try:catch and provision file count limit on adapter migration

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: