### PR TITLE
Fix: core Tests against new PHP8 master on boilerplate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: '2pisoftware/cmfive-boilerplate'
-          ref: 'feature/PHP8.1'
+          ref: 'master'
 
       # Pre-requisites Prepare Cmfive Environment
       - name: Setup cmfive Test Environment


### PR DESCRIPTION
## Description
Boilerplate 8.1 feature branch dissolved to master = so update core ci