### PR TITLE
Coalesce Null to array when Checking CSRF Token

### DIFF
--- a/system/web.php
+++ b/system/web.php
@@ -732,7 +732,7 @@ class Web
             if (Config::get('system.csrf.enabled') === true) {
                 $allowed = Config::get('system.csrf.protected');
                 if (!empty($allowed[$this->_module]) || (!empty($this->_submodule) && !empty($allowed[$this->_module . '-' . $this->_submodule]))) {
-                    if (in_array($this->_action, $allowed[$this->_module]) || (!empty($this->_submodule) && in_array($this->_action, $allowed[$this->_module . '-' . $this->_submodule]))) {
+                    if (in_array($this->_action, $allowed[$this->_module] ?? []) || (!empty($this->_submodule) && in_array($this->_action, $allowed[$this->_module . '-' . $this->_submodule] ?? []))) {
                         // If we get here then we are configured to enforce CSRF checking
                         LogService::getInstance($this)->debug("Checking CSRF");
                         try {


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x ] I'm using the correct PHP Version (8.1).
- [x ] I've added comments to any new methods I've created or where else relevant.
- [x ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [x ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
Coalesce null string to null array when checking CSRF token

<!-- List your changes as a dot point list. -->
## Changelog
web.php line 735

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: