### PR TITLE
Fix taskweek.php undefined variable warnings

### DIFF
--- a/system/modules/task/actions/taskweek.php
+++ b/system/modules/task/actions/taskweek.php
@@ -78,9 +78,9 @@ function taskweek_ALL(Web &$w)
     }
 
     // load the search filters
-    $a = Html::select("assignee", $members, Request::mixed('assignee'));
+    $a = Html::select("assignee", $members ?? [], Request::mixed('assignee'));
     $w->ctx("assignee", $a);
 
-    $taskgroups = Html::select("taskgroup", $group, Request::mixed('taskgroup'));
+    $taskgroups = Html::select("taskgroup", $group ?? [], Request::mixed('taskgroup'));
     $w->ctx("taskgroups", $taskgroups);
 }


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [ ] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: