### PR TITLE
fix: fix run report when run without a form

### DIFF
--- a/system/modules/report/actions/runreport.php
+++ b/system/modules/report/actions/runreport.php
@@ -27,7 +27,7 @@ function runreport_ALL(Web &$w)
                     $form = $rep->getReportCriteria();
 
                     // Determine if it's a multicolform
-                    $section_key = array_keys($form);
+                    $section_key = array_keys($form ?? []);
                     if (!empty($section_key[0])) {
                         $section_key = $section_key[0];
                     } else {


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [ ] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: