### PR TITLE
fix: fix issue with pagination pathing from attachments partial

### DIFF
--- a/system/html.php
+++ b/system/html.php
@@ -1106,7 +1106,7 @@ class Html
     ): string {
         // Build URL for pagination.
         $url_parsed = parse_url($base_url);
-        $url_string = '/' . $url_parsed["path"];
+        $url_string = $url_parsed["path"];
         $url_string .= (empty($url_parsed["query"]) ? "?" : "?" . $url_parsed["query"] . "&") . $sort_query_param . "=" . $sort . "&" . $sort_direction_param . "=" . $sort_direction;
         $url_string .= (!empty($url_parsed["fragment"]) ? "#" . $url_parsed["fragment"] : "");
 

--- a/system/modules/file/partials/actions/listattachments.php
+++ b/system/modules/file/partials/actions/listattachments.php
@@ -7,6 +7,10 @@ function listattachments(\Web $w, $params)
     $object = $params["object"];
     $redirect = $params["redirect"];
 
+    if ($redirect[0] !== '/') {
+        $redirect = '/' . $redirect;
+    }
+
     $page = $w->sessionOrRequest("attachment__" . hash("crc32", get_class($object) . $object->id) . "__page", 1);
     $page_size = 6;
     $w->ctx("page", $page);


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: