### PR TITLE
fix: fix Form cron SQL issues

### DIFF
--- a/system/modules/form/actions/cron/updateformview.php
+++ b/system/modules/form/actions/cron/updateformview.php
@@ -7,17 +7,26 @@ function updateformview_ALL(Web $w) {
 	if (!empty($forms)) {
 		foreach ($forms as $form) {
 			$settings = 'SET SESSION group_concat_max_len = 1000000';
-			$set = $w->db->query($settings)->execute();
+			$w->db->query($settings)->execute();
 
 			$form_id = $form->id;
 			$query = 'SELECT CONCAT("SELECT form_instance.id as instance_id, form_instance.form_id as form_id, form_instance.object_class as object_class, form_instance.object_id as object_id, CASE WHEN form_instance.object_class = ""FormValue"" THEN (SELECT fv.form_instance_id FROM form_value fv WHERE fv.id = form_instance.object_id) ELSE NULL END as parent_instance_id, ", GROUP_CONCAT("t_", form_field.technical_name, ".value AS ", form_field.technical_name), " FROM form LEFT JOIN form_instance ON (form_instance.form_id = form.id AND form_instance.is_deleted = 0) ", GROUP_CONCAT("LEFT JOIN form_value AS t_", form_field.technical_name, " ON (form_instance.id = t_", form_field.technical_name, ".form_instance_id AND t_", form_field.technical_name, ".form_field_id = ", QUOTE(form_field.id), ")" SEPARATOR " "  ), " WHERE form.id = ' . $form_id .' ") as "view_query" FROM form_field WHERE form_id = ' . $form_id;
 
 			$result = $w->db->query($query)->fetch(PDO::FETCH_ASSOC);
 
-			$view_name = str_replace(' ', '_', $form->title) . '_view';
-			$query2 = 'CREATE OR REPLACE VIEW ' . $view_name . ' AS ' . $result['view_query'];
-
-			$view = $w->db->query($query2)->execute();
+            if (!empty($result['view_query'])) {
+                $view_name = str_replace([' ', '#', '\'', '"', ';'], '_', $form->title) . '_view';
+                
+                /** @var PDOStatement */
+                $statement = $w->db->_prepare('CREATE OR REPLACE VIEW ? AS ?');
+                try {
+                    if (!$statement->execute([$view_name, $result['view_query']])) {
+                        LogService::getInstance($w)->error('Failed to create view for form ' . $form->title);
+                    }
+                } catch (PDOException $e) {
+                    LogService::getInstance($w)->error('Failed to create view for form ' . $form->title . ': ' . $e->getMessage());
+                }
+            }
 		}
 	}
 }


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.

<!-- Add a short description. -->
## Description
Fixes 2 issues with the Form crom updateformview action:
- If a view failed to create (can be cause by no form instances) then the script would crash
- Trying to insert special characters, malicious or otherwise was causing a crash - they now get logged and loop continues

<!-- List your changes as a dot point list. -->
## Changelog
- Tidied up variable assignments
- Extended char replacement when creating the view name
- Transitioned to PDO prepared statement when creating the view to mitigate any possibility of SQL injection attack
- Added try/catch and prepared statement check to log issues that may still arise

<!-- Add any important refs or issues numbers. -->
refs: @chrisbateman
issues: