### PR TITLE
Remove node latest and php 8.2 on dev branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php_version: [7.4, 8.0, 8.1, 8.2, 8.3]
+        php_version: [7.4, 8.0, 8.1, 8.3]
     steps:
     - name: Get phpcs
       run: wget https://raw.githubusercontent.com/2pisoftware/cmfive-boilerplate/master/phpcs.xml
@@ -41,7 +41,7 @@ jobs:
     needs: [ php-codesniffer]
     strategy:
       matrix:
-        node_version: [18, 20, latest]
+        node_version: [18, 20]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Remove node latest and php 8.2 on dev branch

<!-- Have you made sure the following is correct? -->
## Checklist
- [ ] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: