### PR TITLE
Fix install warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
 
           # Create Cmfive container
           echo "Starting Cmfive"
-          docker run --name cmfive -d -p 80:80 \
+          docker run --name cmfive -d -p 3000:80 \
             -v ${{ github.workspace }}/core/system:/var/www/html/system \
             -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php \
             -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,23 +43,71 @@ jobs:
       matrix:
         node_version: [18, 20]
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: main
+
+      - name: Checkout Boilerplate
+        uses: actions/checkout@v4
         with:
           repository: '2pisoftware/cmfive-boilerplate'
           ref: 'develop'
+          path: boilerplate
 
       # Pre-requisites Prepare Cmfive Environment
+      - name: Pull Docker images
+        run: |
+          docker pull ghcr.io/2pisoftware/cmfive:develop
+          docker pull mysql:8
+
       - name: Start containers
         run: |
-          cp .codepipeline/test_agent/configs/test_agent-config.php config.php
+          # Create MySQL 8 container
+          docker run --name mysql-8 -d -p 3306:3306 \
+            -e MYSQL_ROOT_PASSWORD=root \
+            -e MYSQL_DATABASE=cmfive_test \
+            -e MYSQL_USER=cmfive_test \
+            -e MYSQL_PASSWORD=cmfive_test \
+            mysql:8
+
+          # Wait for MySQL to start
+          time=0
+          while ! docker exec mysql-8 mysqladmin ping -hlocalhost --silent; do
+            sleep 1
+            time=$((time+1))
+            if [ $time -gt 60 ]; then
+              echo "MySQL failed to start"
+              exit 1
+            fi
+          done
+
+          # Create Cmfive container
+          docker run --name cmfive -d -p 80:80 \
+            -v ${{ github.workspace }}/main/system:/var/www/html/system \
+            -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php \
+            ghcr.io/2pisoftware/cmfive:develop
+
+          # Wait for cmfive healthcheck to be healthy
+          time=0
+          while [ "$(docker inspect -f '{{.State.Health.Status}}' cmfive)" != "healthy" ]; do
+            sleep 1
+            time=$((time+1))
+            if [ $time -gt 60 ]; then
+              echo "Cmfive failed to start"
+              exit 1
+            fi
+          done
+
+          cp boilerplate/.codepipeline/test_agent/configs/test_agent-config.php config.php
           docker compose -f docker-compose.yml up --build -d --wait --wait-timeout 300
-          
+
       # Pre-requisites Prepare Cmfive Environment
       - name: Setup cmfive Test Environment
         run: |
             echo DBCreate 
             docker exec -t mysql-8 bash -c "mysql -h 127.0.0.1 -u'root' -p'root' --execute \"CREATE DATABASE cmfive_test; CREATE USER cmfive_test@'%' IDENTIFIED BY 'cmfive_test'; GRANT ALL PRIVILEGES ON cmfive_test.* TO cmfive_test@'%'; GRANT PROCESS ON *.* TO cmfive_test@'%'; FLUSH PRIVILEGES;\""
-            docker exec -t cmfive bash -c "chmod -R 777 ./*"
+            docker exec -t cmfive sh -c "chmod -R ugo=rwX /var/www/html*"
 
       - name: Inject configs into cmfive Test Environment
         run: |
@@ -68,11 +116,11 @@ jobs:
 
       - name: Prepare cmfive Test Backend
         run: |
-          docker exec cmfive bash -c "cd ./test/ && sh ./.install/install.sh && chmod -R 777 /var/www/html/test/Codeception/tests"
+          docker exec cmfive sh -c "cd ./test/ && sh ./.install/install.sh && chmod -R 777 /var/www/html/test/Codeception/tests"
 
       - name: Prepare cmfive Test DB
         run: |
-          docker exec -t cmfive bash -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php testDB setup; exit \$?";
+          docker exec -t cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php testDB setup; exit \$?";
         
       # Build new layout
       - uses: actions/setup-node@v4
@@ -82,7 +130,7 @@ jobs:
       # Run Unit Tests
       - name: "Run unit tests"
         run: |
-          docker exec cmfive bash -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php tests unit all; exit \$?"
+          docker exec cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php tests unit all; exit \$?"
           if [ $? -gt 0 ]; then
             echo "Admin module tests failed"
           fi
@@ -95,7 +143,7 @@ jobs:
       # Run Acceptance Tests
       - name: "Confirm Codeception setup"
         run: |        
-          docker exec cmfive bash -c "ls -lah -R /var/www/html/test/Codeception/tests && cat /var/www/html/test/Codeception/*.yml && cat /var/www/html/test/Codeception/tests/*.yml"
+          docker exec cmfive sh -c "ls -lah -R /var/www/html/test/Codeception/tests && cat /var/www/html/test/Codeception/*.yml && cat /var/www/html/test/Codeception/tests/*.yml"
 
       - name: "Run admin module tests"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
           done
 
           # Get .composer dir ready
+          if [ ! -d .composer ]; then
+            mkdir .composer
+          fi
           chmod -R ugo=rwX .composer
 
           # Create Cmfive container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,9 @@ jobs:
 
       - name: Compile the theme
         run: |
-          docker run node:18-alpine \
-            -v ${{ github.workspace }}/core/system/templates/base:/var/www/html/system/templates/base \
-            sh -c "cd /var/www/html/system/templates/base && npm install && npm run production"
+          cd core/system/templates/base
+          npm ci || npm install
+          npm run build
 
       # Pre-requisites Prepare Cmfive Environment
       - name: Pull Docker images
@@ -178,7 +178,7 @@ jobs:
       - name: Setup Playwright
         run: |
           # Link system so it can find tests
-          ln -s boilerplate/system core/system
+          ln -s core/system boilerplate/system 
 
           cd boilerplate/test/playwright
           npm ci
@@ -295,6 +295,6 @@ jobs:
 
       # Save composer cache from cmfive container
       - name: Save composer cache
-        if: ${{ success() }}
+        if: ${{ always() }}
         run: |
           docker cp cmfive:/var/www/html/.composer .composer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,15 @@ jobs:
           ref: 'develop'
           path: boilerplate
 
+      # Define composer cache
+      - name: Composer cache
+        uses: actions/cache@v4
+        with:
+          path: .composer
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
       - name: Compile the theme
         run: |
           docker run node:18-alpine \
@@ -110,6 +119,14 @@ jobs:
             fi
           done
 
+      # Load composer cache
+      - name: Load composer cache
+        if: runner.os == 'Linux'
+        run: |
+          if [ -d .composer ]; then
+            docker cp .composer cmfive:/home/cmfive/
+          fi
+
       # Pre-requisites Prepare Cmfive Environment
       - name: Setup cmfive Test Environment
         run: |
@@ -134,7 +151,8 @@ jobs:
             "apk add --no-cache php81-dom php81-xmlwriter php81-tokenizer";
 
           # Install Codeception
-          docker exec cmfive sh -c "cd ./test/ && sh ./.install/install.sh && chmod -R 777 /var/www/html/test/Codeception/tests"
+          docker exec -u cmfive cmfive sh -c \
+            "cd ./test/ && sh ./.install/install.sh && chmod -R 777 /var/www/html/test/Codeception/tests"
 
       - name: Prepare cmfive Test DB
         run: |
@@ -155,7 +173,7 @@ jobs:
         # Setup playwright
       - name: Setup Playwright
         run: |
-          cd test/playwright
+          cd boilerplate/test/playwright
           npm ci
           npx playwright install --with-deps
       # Run Acceptance Tests
@@ -166,7 +184,7 @@ jobs:
       - name: "Run admin module tests"
         run: |
             sudo chmod 777 -R system/modules/admin/install/migrations/
-            cd test/playwright
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="admin" --reporter="github"
             if [ $? -gt 0 ]; then
@@ -174,7 +192,7 @@ jobs:
             fi
       - name: "Run channel module tests"
         run: |
-            cd test/playwright
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="channel" --reporter="github"
             if [ $? -gt 0 ]; then
@@ -182,7 +200,7 @@ jobs:
             fi
       - name: "Run form module tests"
         run: |
-            cd test/playwright
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="form" --reporter="github"
             if [ $? -gt 0 ]; then
@@ -190,7 +208,7 @@ jobs:
             fi
       - name: "Run report module tests"
         run: |
-          cd test/playwright
+          cd boilerplate/test/playwright
           npm run build
           npm run test --module="report" --reporter="github"
           if [ $? -gt 0 ]; then
@@ -198,7 +216,7 @@ jobs:
           fi
       - name: "Run tag module tests"
         run: |
-            cd test/playwright
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="tag" --reporter="github"
             if [ $? -gt 0 ]; then
@@ -206,7 +224,7 @@ jobs:
             fi
       - name: "Run task module tests"
         run: |
-            cd test/playwright
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="task" --reporter="github"
             if [ $? -gt 0 ]; then
@@ -214,7 +232,7 @@ jobs:
             fi
       - name: "Run timelog module tests"
         run: |
-            cd test/playwright
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="timelog" --reporter="github"
             if [ $? -gt 0 ]; then
@@ -267,3 +285,9 @@ jobs:
             test/playwright/test-results/
             test/playwright/playwright-report/
           retention-days: 5
+
+      # Save composer cache from cmfive container
+      - name: Save composer cache
+        if: ${{ success() }}
+        run: |
+          docker cp cmfive:/var/www/html/.composer .composer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Cache .composer
         uses: actions/cache@v2
         with:
-          path: ${{ github.workspace }}/.composer
+          path: /tmp/.composer
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
@@ -107,15 +107,15 @@ jobs:
           done
 
           # Get .composer dir ready
-          if [ ! -d ${{ github.workspace }}/.composer ]; then
-            mkdir ${{ github.workspace }}/.composer
+          if [ ! -d /tmp/.composer ]; then
+            mkdir /tmp/.composer
           fi
-          chmod -R ugo=rwX ${{ github.workspace }}/.composer
+          chmod -R ugo=rwX /tmp/.composer
 
           # Create Cmfive container
           echo "Starting Cmfive"
           docker run --name cmfive -d -p 3000:80 \
-            -v ${{ github.workspace }}/.composer/:/home/cmfive/.composer/:rw \
+            -v /tmp/.composer:/home/cmfive/.composer/:rw \
             -v ${{ github.workspace }}/core/system:/var/www/html/system:rw \
             -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php:rw \
             -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test:rw \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,14 @@ jobs:
 
       - name: Prepare cmfive Test Backend
         run: |
+          # Install packages required for the tests
+          docker exec -u root -t cmfive sh -c "apk add php81-dom";
+
+          # Install Codeception
           docker exec cmfive sh -c "cd ./test/ && sh ./.install/install.sh && chmod -R 777 /var/www/html/test/Codeception/tests"
 
       - name: Prepare cmfive Test DB
         run: |
-          # Install packages required for the tests
-          docker exec -u root -t cmfive sh -c "apk add php81-dom";
-
           docker exec -t cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php testDB setup; exit \$?";
         
       # Build new layout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,14 @@ jobs:
       - name: Inject configs into cmfive Test Environment
         run: |
           echo "Inheriting test_agent config from PIPELINE"
-          echo 'Config::append("tests", ["testrunner" => "ENABLED"]);' >> config.php
+
+          # Define extra config
+          CONFIG='
+          Config::append("tests", ["testrunner" => "ENABLED"])
+          '
+
+          # Write extra config to cmfive container
+          docker exec -t cmfive sh -c "echo \"$CONFIG\" >> /var/www/html/config.php"
 
       - name: Prepare cmfive Test Backend
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
         run: |
           # Link system so it can find tests
           ln -s core/system boilerplate/system 
+          ls boilerplate/system
 
           cd boilerplate/test/playwright
           npm ci
@@ -190,7 +191,7 @@ jobs:
 
       - name: "Run admin module tests"
         run: |
-            sudo chmod ugo=rwX -R core/system/modules/admin/install/migrations/
+            sudo chmod ugo=rwX -R boilerplate/system/modules/admin/install/migrations/
             cd boilerplate/test/playwright
             npm run build
             npm run test --module="admin" --reporter="github"
@@ -270,6 +271,12 @@ jobs:
           check mysql-8
           check cmfive
 
+      # Save composer cache from cmfive container
+      - name: Save composer cache
+        if: always()
+        run: |
+          docker cp cmfive:/var/www/html/.composer .composer
+
       - name: Stop containers
         # the containers should be stopped regardless of 
         # the test result
@@ -293,8 +300,3 @@ jobs:
             test/playwright/playwright-report/
           retention-days: 5
 
-      # Save composer cache from cmfive container
-      - name: Save composer cache
-        if: ${{ always() }}
-        run: |
-          docker cp cmfive:/var/www/html/.composer .composer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          path: main
+          path: core
 
       - name: Checkout Boilerplate
         uses: actions/checkout@v4
@@ -54,6 +54,15 @@ jobs:
           repository: '2pisoftware/cmfive-boilerplate'
           ref: 'develop'
           path: boilerplate
+
+      - name: Compile the theme
+        run: |
+          docker run node:18-alpine \
+            -v ${{ github.workspace }}/core/system/templates/base:/var/www/html/system/templates/base \
+            sh -c \
+            "cd /var/www/html/system/templates/base && \
+            npm install && \
+            npm run production"
 
       # Pre-requisites Prepare Cmfive Environment
       - name: Pull Docker images
@@ -64,6 +73,7 @@ jobs:
       - name: Start containers
         run: |
           # Create MySQL 8 container
+          echo "Starting MySQL 8"
           docker run --name mysql-8 -d -p 3306:3306 \
             -e MYSQL_ROOT_PASSWORD=root \
             -e MYSQL_DATABASE=cmfive_test \
@@ -72,8 +82,9 @@ jobs:
             mysql:8
 
           # Wait for MySQL to start
+          echo "Waiting for MySQL to start"
           time=0
-          while ! docker exec mysql-8 sh -c "mysqladmin ping -hlocalhost --silent"; do
+          while ! docker exec mysql-8 mysqladmin ping -ucmfive_test -pcmfive_test --silent; do
             sleep 1
             time=$((time+1))
             if [ $time -gt 60 ]; then
@@ -83,12 +94,14 @@ jobs:
           done
 
           # Create Cmfive container
+          echo "Starting Cmfive"
           docker run --name cmfive -d -p 80:80 \
-            -v ${{ github.workspace }}/main/system:/var/www/html/system \
+            -v ${{ github.workspace }}/core/system:/var/www/html/system \
             -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php \
             ghcr.io/2pisoftware/cmfive:develop
 
           # Wait for cmfive healthcheck to be healthy
+          echo "Waiting for Cmfive to start"
           time=0
           while [ "$(docker inspect -f '{{.State.Health.Status}}' cmfive)" != "healthy" ]; do
             sleep 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
       # Run Unit Tests
       - name: "Run unit tests"
         run: |
-          docker exec -u root cmfive chmod -R ug=rwX /var/www/html/test/Codeception/
+          docker exec -u root cmfive chmod -R ugo=rwX /var/www/html/test/Codeception/
           docker exec -u cmfive cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php tests unit all; exit \$?"
           if [ $? -gt 0 ]; then
             echo "Admin module tests failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
       # Run Unit Tests
       - name: "Run unit tests"
         run: |
-          docker exec -u root cmfive chmod -R ugo=rwX /var/www/html/test/Codeception/
+          docker exec -u root cmfive chmod -R ugo=rwX /var/www/html/test/
           docker exec -u cmfive cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php tests unit all; exit \$?"
           if [ $? -gt 0 ]; then
             echo "Admin module tests failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,10 @@ jobs:
         # the test result
         if: always()
         run: |
-          docker-compose down
+          docker stop cmfive
+          docker stop mysql-8
+          docker rm cmfive
+          docker rm mysql-8
 
       # Store Test Results
       - name: Test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
       # Run Unit Tests
       - name: "Run unit tests"
         run: |
-          docker exec cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php tests unit all; exit \$?"
+          docker exec -u cmfive cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php tests unit all; exit \$?"
           if [ $? -gt 0 ]; then
             echo "Admin module tests failed"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
           docker run --name cmfive -d -p 80:80 \
             -v ${{ github.workspace }}/core/system:/var/www/html/system \
             -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php \
+            -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test \
             ghcr.io/2pisoftware/cmfive:develop
 
           # Wait for cmfive healthcheck to be healthy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
             fi
 
       - name: Get container healthchecks
-        if: always()
+        if: failure()
         run: |
           docker inspect --format='{{json .State.Health.Status}}' cmfive
           docker inspect --format='{{json .State.Health.Status}}' mysql-8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,12 +179,15 @@ jobs:
         run: |
           # Link system so it can find tests
           echo "Contents of core/system"
-          ls -la core/system
+          ls -la core/system/
           
           echo "Linking core/system to boilerplate/system"
-          ln -s core/system boilerplate/system 
+          cd boilerplate
+          ln -s ../core/system system 
+          cd ..
           ls -la boilerplate/system
 
+          echo "Installing Playwright"
           cd boilerplate/test/playwright
           npm ci
           npx playwright install --with-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,9 @@ jobs:
         # Setup playwright
       - name: Setup Playwright
         run: |
+          # Link system so it can find tests
+          ln -s boilerplate/system core/system
+
           cd boilerplate/test/playwright
           npm ci
           npx playwright install --with-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
             fi
           done
 
+          # Get .composer dir ready
+          chmod -R ugo=rwX .composer
+
           # Create Cmfive container
           echo "Starting Cmfive"
           docker run --name cmfive -d -p 3000:80 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,12 @@ jobs:
             if docker inspect $container --format='{{.State.Health.Status}}' >/dev/null 2>&1; then
               health=$(docker inspect --format='{{json .State.Health.Status}}' $container)
               if [ "$health" != "\"healthy\"" ]; then
-                echo "Container is not healthy"
+                echo "CONTAINER IS NOT HEALTHY"
+                echo "==== STATUS ===="
                 docker inspect --format='{{json .State.Health}}' $container
+                echo "==== LOGS ===="
+                docker logs $container
+                echo "==== END ===="
               else
                 echo "Container is healthy"
               fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
           # Change owner
           sudo chown -R 1000:1000 .
 
+          # Create docker network
+          docker network create cmfive
+
           # Create MySQL 8 container
           echo "Starting MySQL 8"
           docker run --name mysql-8 -d -p 3306:3306 \
@@ -88,6 +91,7 @@ jobs:
             -e MYSQL_DATABASE=cmfive_test \
             -e MYSQL_USER=cmfive_test \
             -e MYSQL_PASSWORD=cmfive_test \
+            --network=cmfive \
             mysql:8
 
           # Wait for MySQL to start
@@ -113,6 +117,7 @@ jobs:
             -e DB_USERNAME=cmfive_test \
             -e DB_PASSWORD=cmfive_test \
             -e DB_DATABASE=cmfive_test \
+            --network=cmfive \
             ghcr.io/2pisoftware/cmfive:develop
 
           # Wait for cmfive healthcheck to be healthy
@@ -278,10 +283,9 @@ jobs:
         # the test result
         if: always()
         run: |
-          docker stop cmfive
-          docker stop mysql-8
-          docker rm cmfive
-          docker rm mysql-8
+          docker rm cmfive -f
+          docker rm mysql-8 -f
+          docker network rm cmfive
 
       # Store Test Results
       - name: Test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,13 @@ jobs:
 
       # Define cache for .composer
       - name: Cache .composer
-        uses: actions/cache@v2
+        uses: actions/cache@v4
+        id: cache
         with:
-          path: /tmp/.composer
+          path: |
+            /tmp/.composer
+            ${{ github.workspace }}/boilerplate/composer
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
 
       - name: Compile the theme
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,11 @@ jobs:
             -v ${{ github.workspace }}/core/system:/var/www/html/system \
             -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php \
             -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test \
+            -v ${{ github.workspace }}/boilerplate/storage:/var/www/html/storage \
             ghcr.io/2pisoftware/cmfive:develop
+
+          # Install core
+          docker exec -u cmfive cmfive sh -c "php cmfive.php core install"
 
           # Wait for cmfive healthcheck to be healthy
           echo "Waiting for Cmfive to start"
@@ -257,7 +261,7 @@ jobs:
       - name: Get container logs
         if: failure()
         run: |
-          docker logs check cmfive
+          docker logs cmfive
 
       # Save composer cache from cmfive container
       - name: Save composer cache
@@ -282,9 +286,9 @@ jobs:
         with:
           name: test-output-${{matrix.node_version}}
           path: |
-            test/Codeception/tests/_output/
-            storage/log/
-            test/playwright/test-results/
-            test/playwright/playwright-report/
+            boilerplate/test/Codeception/tests/_output/
+            boilerplate/storage/log/
+            boilerplate/test/playwright/test-results/
+            boilerplate/test/playwright/playwright-report/
           retention-days: 5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,11 +55,11 @@ jobs:
           ref: 'develop'
           path: boilerplate
 
-      # Define composer cache
-      - name: Composer cache
-        uses: actions/cache@v4
+      # Define cache for .composer
+      - name: Cache .composer
+        uses: actions/cache@v2
         with:
-          path: .composer
+          path: ${{ github.workspace }}/.composer
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
@@ -107,15 +107,15 @@ jobs:
           done
 
           # Get .composer dir ready
-          if [ ! -d .composer ]; then
-            mkdir .composer
+          if [ ! -d ${{ github.workspace }}/.composer ]; then
+            mkdir ${{ github.workspace }}/.composer
           fi
-          chmod -R ugo=rwX .composer
+          chmod -R ugo=rwX ${{ github.workspace }}/.composer
 
           # Create Cmfive container
           echo "Starting Cmfive"
           docker run --name cmfive -d -p 3000:80 \
-            -v ${{ github.workspace }}.composer/:/home/cmfive/.composer/:rw \
+            -v ${{ github.workspace }}/.composer/:/home/cmfive/.composer/:rw \
             -v ${{ github.workspace }}/core/system:/var/www/html/system:rw \
             -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php:rw \
             -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test:rw \
@@ -275,12 +275,6 @@ jobs:
         if: failure()
         run: |
           docker logs cmfive
-
-      # Save composer cache from cmfive container
-      - name: Save composer cache
-        if: always()
-        run: |
-          docker cp cmfive:/home/cmfive/.composer .composer
 
       - name: Stop containers
         # the containers should be stopped regardless of 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
 
           # Define extra config
           CONFIG='
-          Config::append("tests", ["testrunner" => "ENABLED"])
+          Config::append("tests", ["testrunner" => "ENABLED"]);
           '
 
           # Write extra config to cmfive container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,9 +150,13 @@ jobs:
           docker exec -u root -t cmfive sh -c \
             "apk add --no-cache php81-dom php81-xmlwriter php81-tokenizer";
 
+          # Change owner of the test directory
+          docker exec -u root -t cmfive sh -c \
+            "chown -R cmfive:cmfive /var/www/html/test";
+
           # Install Codeception
           docker exec -u cmfive cmfive sh -c \
-            "cd ./test/ && sh ./.install/install.sh && chmod -R 777 /var/www/html/test/Codeception/tests"
+            "cd /var/www/html/test/ && sh ./.install/install.sh"
 
       - name: Prepare cmfive Test DB
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,23 +215,23 @@ jobs:
         run: |        
           docker exec cmfive sh -c "ls -lah -R /var/www/html/test/Codeception/tests && cat /var/www/html/test/Codeception/*.yml && cat /var/www/html/test/Codeception/tests/*.yml"
 
-      - name: "Run admin module tests"
-        run: |
-            sudo chmod ugo=rwX -R boilerplate/system/modules/admin/install/migrations/
-            cd boilerplate/test/playwright
-            npm run build
-            npm run test --module="admin" --reporter="github"
-            if [ $? -gt 0 ]; then
-                echo "Admin module tests failed"
-            fi
-      - name: "Run channel module tests"
-        run: |
-            cd boilerplate/test/playwright
-            npm run build
-            npm run test --module="channel" --reporter="github"
-            if [ $? -gt 0 ]; then
-                echo "Channel module tests failed"
-            fi
+      # - name: "Run admin module tests"
+      #   run: |
+      #       sudo chmod ugo=rwX -R boilerplate/system/modules/admin/install/migrations/
+      #       cd boilerplate/test/playwright
+      #       npm run build
+      #       npm run test --module="admin" --reporter="github"
+      #       if [ $? -gt 0 ]; then
+      #           echo "Admin module tests failed"
+      #       fi
+      # - name: "Run channel module tests"
+      #   run: |
+      #       cd boilerplate/test/playwright
+      #       npm run build
+      #       npm run test --module="channel" --reporter="github"
+      #       if [ $? -gt 0 ]; then
+      #           echo "Channel module tests failed"
+      #       fi
       - name: "Run form module tests"
         run: |
             cd boilerplate/test/playwright
@@ -264,14 +264,14 @@ jobs:
             if [ $? -gt 0 ]; then
                 echo "Task module tests failed"
             fi
-      - name: "Run timelog module tests"
-        run: |
-            cd boilerplate/test/playwright
-            npm run build
-            npm run test --module="timelog" --reporter="github"
-            if [ $? -gt 0 ]; then
-                echo "Timelog module tests failed"
-            fi
+      # - name: "Run timelog module tests"
+      #   run: |
+      #       cd boilerplate/test/playwright
+      #       npm run build
+      #       npm run test --module="timelog" --reporter="github"
+      #       if [ $? -gt 0 ]; then
+      #           echo "Timelog module tests failed"
+      #       fi
 
       - name: Get container logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,6 @@ jobs:
             fi
           done
 
-          cp boilerplate/.codepipeline/test_agent/configs/test_agent-config.php config.php
-          docker compose -f docker-compose.yml up --build -d --wait --wait-timeout 300
-
       # Pre-requisites Prepare Cmfive Environment
       - name: Setup cmfive Test Environment
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,29 +254,10 @@ jobs:
                 echo "Timelog module tests failed"
             fi
 
-      - name: Get container healthchecks
+      - name: Get container logs
         if: failure()
         run: |
-          function check() {
-            container=$1
-            if docker inspect $container --format='{{.State.Health.Status}}' >/dev/null 2>&1; then
-              health=$(docker inspect --format='{{json .State.Health.Status}}' $container)
-              if [ "$health" != "\"healthy\"" ]; then
-                echo "CONTAINER IS NOT HEALTHY"
-                echo "==== STATUS ===="
-                docker inspect --format='{{json .State.Health}}' $container
-                echo "==== LOGS ===="
-                docker logs $container
-                echo "==== END ===="
-              else
-                echo "Container is healthy"
-              fi
-            else
-              echo "Container does not have a health check"
-            fi
-          }
-          check mysql-8
-          check cmfive
+          docker logs check cmfive
 
       # Save composer cache from cmfive container
       - name: Save composer cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,23 +215,23 @@ jobs:
         run: |        
           docker exec cmfive sh -c "ls -lah -R /var/www/html/test/Codeception/tests && cat /var/www/html/test/Codeception/*.yml && cat /var/www/html/test/Codeception/tests/*.yml"
 
-      # - name: "Run admin module tests"
-      #   run: |
-      #       sudo chmod ugo=rwX -R boilerplate/system/modules/admin/install/migrations/
-      #       cd boilerplate/test/playwright
-      #       npm run build
-      #       npm run test --module="admin" --reporter="github"
-      #       if [ $? -gt 0 ]; then
-      #           echo "Admin module tests failed"
-      #       fi
-      # - name: "Run channel module tests"
-      #   run: |
-      #       cd boilerplate/test/playwright
-      #       npm run build
-      #       npm run test --module="channel" --reporter="github"
-      #       if [ $? -gt 0 ]; then
-      #           echo "Channel module tests failed"
-      #       fi
+      - name: "Run admin module tests"
+        run: |
+            sudo chmod ugo=rwX -R boilerplate/system/modules/admin/install/migrations/
+            cd boilerplate/test/playwright
+            npm run build
+            npm run test --module="admin" --reporter="github"
+            if [ $? -gt 0 ]; then
+                echo "Admin module tests failed"
+            fi
+      - name: "Run channel module tests"
+        run: |
+            cd boilerplate/test/playwright
+            npm run build
+            npm run test --module="channel" --reporter="github"
+            if [ $? -gt 0 ]; then
+                echo "Channel module tests failed"
+            fi
       - name: "Run form module tests"
         run: |
             cd boilerplate/test/playwright
@@ -264,14 +264,14 @@ jobs:
             if [ $? -gt 0 ]; then
                 echo "Task module tests failed"
             fi
-      # - name: "Run timelog module tests"
-      #   run: |
-      #       cd boilerplate/test/playwright
-      #       npm run build
-      #       npm run test --module="timelog" --reporter="github"
-      #       if [ $? -gt 0 ]; then
-      #           echo "Timelog module tests failed"
-      #       fi
+      - name: "Run timelog module tests"
+        run: |
+            cd boilerplate/test/playwright
+            npm run build
+            npm run test --module="timelog" --reporter="github"
+            if [ $? -gt 0 ]; then
+                echo "Timelog module tests failed"
+            fi
 
       - name: Get container logs
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
             ghcr.io/2pisoftware/cmfive:develop
 
           # Install core
-          docker exec -u cmfive cmfive sh -c "php cmfive.php core install"
+          docker exec -u cmfive cmfive sh -c "chmod -R ugo=rwX . && php cmfive.php core install"
 
           # Wait for cmfive healthcheck to be healthy
           echo "Waiting for Cmfive to start"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,11 +155,19 @@ jobs:
                 echo "Timelog module tests failed"
             fi
 
+      - name: Get container healthchecks
+        if: always()
+        run: |
+          docker inspect --format='{{json .State.Health.Status}}' cmfive
+          docker inspect --format='{{json .State.Health.Status}}' mysql-8
+          docker inspect --format='{{json .State.Health.Status}}' node-compiler
+
       - name: Stop containers
         # the containers should be stopped regardless of 
         # the test result
         if: always()
-        run: docker-compose down
+        run: |
+          docker-compose down
 
       # Store Test Results
       - name: Test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,8 +178,12 @@ jobs:
       - name: Setup Playwright
         run: |
           # Link system so it can find tests
+          echo "Contents of core/system"
+          ls -la core/system
+          
+          echo "Linking core/system to boilerplate/system"
           ln -s core/system boilerplate/system 
-          ls boilerplate/system
+          ls -la boilerplate/system
 
           cd boilerplate/test/playwright
           npm ci
@@ -275,7 +279,7 @@ jobs:
       - name: Save composer cache
         if: always()
         run: |
-          docker cp cmfive:/var/www/html/.composer .composer
+          docker cp cmfive:/home/cmfive/.composer .composer
 
       - name: Stop containers
         # the containers should be stopped regardless of 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,9 +158,23 @@ jobs:
       - name: Get container healthchecks
         if: failure()
         run: |
-          docker inspect --format='{{json .State.Health.Status}}' cmfive
-          docker inspect --format='{{json .State.Health.Status}}' mysql-8
-          docker inspect --format='{{json .State.Health.Status}}' node-compiler
+          services=$(docker compose config --services)
+          for service in $services; do
+            echo "Service: $service"
+            container=$(docker-compose ps -q $service)
+            if docker inspect $container --format='{{.State.Health.Status}}' >/dev/null 2>&1; then
+              health=$(docker inspect --format='{{json .State.Health.Status}}' $container)
+              if [ "$health" != "\"healthy\"" ]; then
+                echo "Container is not healthy"
+                docker inspect --format='{{json .State.Health}}' $container
+              else
+                echo "Container is healthy"
+              fi
+            else
+              echo "Container does not have a health check"
+            fi
+            echo ""
+          done
 
       - name: Stop containers
         # the containers should be stopped regardless of 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         run: |
           # Install packages required for the tests
           docker exec -u root -t cmfive sh -c \
-            "apk add --no-cache php81-dom php81-xmlwriter php81-tokenizer php81-ctype";
+            "apk add --no-cache php81-dom php81-xmlwriter php81-tokenizer php81-ctype mysql-client mariadb-connector-c-dev";
 
           # Install phpunit
           docker exec -u root -t cmfive sh -c \
@@ -177,7 +177,7 @@ jobs:
 
       - name: Prepare cmfive Test DB
         run: |
-          docker exec -t cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php testDB setup; exit \$?";
+          docker exec -t cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=root DB_PASSWORD=root DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php testDB setup; exit \$?";
         
       # Build new layout
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
           # Create Cmfive container
           echo "Starting Cmfive"
           docker run --name cmfive -d -p 3000:80 \
+            -v ${{ github.workspace }}.composer/:/home/cmfive/.composer/:rw \
             -v ${{ github.workspace }}/core/system:/var/www/html/system:rw \
             -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php:rw \
             -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test:rw \
@@ -131,14 +132,6 @@ jobs:
               exit 1
             fi
           done
-
-      # Load composer cache
-      - name: Load composer cache
-        if: runner.os == 'Linux'
-        run: |
-          if [ -d .composer ]; then
-            docker cp .composer cmfive:/home/cmfive/
-          fi
 
       # Pre-requisites Prepare Cmfive Environment
       - name: Setup cmfive Test Environment
@@ -163,9 +156,9 @@ jobs:
           docker exec -u root -t cmfive sh -c \
             "apk add --no-cache php81-dom php81-xmlwriter php81-tokenizer php81-ctype mysql-client mariadb-connector-c-dev";
 
-          # Install phpunit
-          docker exec -u root -t cmfive sh -c \
-            "cd /usr/local/bin && wget -O phpunit https://phar.phpunit.de/phpunit-10.phar && chmod +x phpunit";
+          # Install phpunit 8
+          docker exec -u root cmfive sh -c \
+            "cd /usr/local/bin && curl -L https://phar.phpunit.de/phpunit-8.phar -o phpunit && chmod +x phpunit && chmod 777 .";
 
           # Change owner of the test directory
           docker exec -u root -t cmfive sh -c \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,10 @@ jobs:
             -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php:rw \
             -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test:rw \
             -v ${{ github.workspace }}/boilerplate/storage:/var/www/html/storage:rw \
+            -e DB_HOST=mysql-8 \
+            -e DB_USERNAME=cmfive_test \
+            -e DB_PASSWORD=cmfive_test \
+            -e DB_DATABASE=cmfive_test \
             ghcr.io/2pisoftware/cmfive:develop
 
           # Wait for cmfive healthcheck to be healthy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Start containers
         run: |
           cp .codepipeline/test_agent/configs/test_agent-config.php config.php
-          docker compose -f docker-compose.yml up --build -d --wait --wait-timeout 120
+          docker compose -f docker-compose.yml up --build -d --wait --wait-timeout 300
           
       # Pre-requisites Prepare Cmfive Environment
       - name: Setup cmfive Test Environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
           # Wait for MySQL to start
           time=0
-          while ! docker exec mysql-8 mysqladmin ping -hlocalhost --silent; do
+          while ! docker exec mysql-8 sh -c "mysqladmin ping -hlocalhost --silent"; do
             sleep 1
             time=$((time+1))
             if [ $time -gt 60 ]; then
@@ -203,10 +203,8 @@ jobs:
       - name: Get container healthchecks
         if: failure()
         run: |
-          services=$(docker compose config --services)
-          for service in $services; do
-            echo "Service: $service"
-            container=$(docker-compose ps -q $service)
+          function check() {
+            container=$1
             if docker inspect $container --format='{{.State.Health.Status}}' >/dev/null 2>&1; then
               health=$(docker inspect --format='{{json .State.Health.Status}}' $container)
               if [ "$health" != "\"healthy\"" ]; then
@@ -222,8 +220,9 @@ jobs:
             else
               echo "Container does not have a health check"
             fi
-            echo ""
-          done
+          }
+          check mysql-8
+          check cmfive
 
       - name: Stop containers
         # the containers should be stopped regardless of 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,9 @@ jobs:
 
       - name: Prepare cmfive Test DB
         run: |
+          # Install packages required for the tests
+          docker exec -u root -t cmfive sh -c "apk add php81-dom";
+
           docker exec -t cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php testDB setup; exit \$?";
         
       # Build new layout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           cd core/system/templates/base
           npm ci || npm install
-          npm run build
+          npm run production
 
       # Pre-requisites Prepare Cmfive Environment
       - name: Pull Docker images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,7 @@ jobs:
         run: |
           docker run node:18-alpine \
             -v ${{ github.workspace }}/core/system/templates/base:/var/www/html/system/templates/base \
-            sh -c \
-            "cd /var/www/html/system/templates/base && \
-            npm install && \
-            npm run production"
+            sh -c "cd /var/www/html/system/templates/base && npm install && npm run production"
 
       # Pre-requisites Prepare Cmfive Environment
       - name: Pull Docker images
@@ -133,7 +130,8 @@ jobs:
       - name: Prepare cmfive Test Backend
         run: |
           # Install packages required for the tests
-          docker exec -u root -t cmfive sh -c "apk add php81-dom";
+          docker exec -u root -t cmfive sh -c \
+            "apk add --no-cache php81-dom php81-xmlwriter php81-tokenizer";
 
           # Install Codeception
           docker exec cmfive sh -c "cd ./test/ && sh ./.install/install.sh && chmod -R 777 /var/www/html/test/Codeception/tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
       # Run Unit Tests
       - name: "Run unit tests"
         run: |
+          chmod -R ug=rwX boilerplate/test/Codeception/
           docker exec -u cmfive cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php tests unit all; exit \$?"
           if [ $? -gt 0 ]; then
             echo "Admin module tests failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,7 @@ jobs:
       # Pre-requisites Prepare Cmfive Environment
       - name: Setup cmfive Test Environment
         run: |
-            echo DBCreate 
-            docker exec -t mysql-8 bash -c "mysql -h 127.0.0.1 -u'root' -p'root' --execute \"CREATE DATABASE cmfive_test; CREATE USER cmfive_test@'%' IDENTIFIED BY 'cmfive_test'; GRANT ALL PRIVILEGES ON cmfive_test.* TO cmfive_test@'%'; GRANT PROCESS ON *.* TO cmfive_test@'%'; FLUSH PRIVILEGES;\""
-            docker exec -t cmfive sh -c "chmod -R ugo=rwX /var/www/html*"
+          docker exec -t cmfive sh -c "chmod -R ugo=rwX /var/www/html*"
 
       - name: Inject configs into cmfive Test Environment
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,14 @@ jobs:
           # Change owner
           sudo chown -R 1000:1000 .
 
+          echo "Linking core/system to boilerplate/system"
+          cd boilerplate
+          sudo ln -s ../core/system system 
+          cd ..
+          ls -la boilerplate/system
+
           # Create docker network
+          echo "Setting up docker"
           docker network create cmfive
 
           # Create MySQL 8 container
@@ -198,12 +205,6 @@ jobs:
           # Link system so it can find tests
           echo "Contents of core/system"
           ls -la core/system/
-          
-          echo "Linking core/system to boilerplate/system"
-          cd boilerplate
-          ln -s ../core/system system 
-          cd ..
-          ls -la boilerplate/system
 
           echo "Installing Playwright"
           cd boilerplate/test/playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
 
           # Define extra config
           CONFIG='
-          Config::append("tests", ["testrunner" => "ENABLED"]);
+          Config::append(\"tests\", [\"testrunner\" => \"ENABLED\"]);
           '
 
           # Write extra config to cmfive container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
 
       - name: Start containers
         run: |
+          # Change owner
+          sudo chown -R 1000:1000 .
+
           # Create MySQL 8 container
           echo "Starting MySQL 8"
           docker run --name mysql-8 -d -p 3306:3306 \
@@ -102,14 +105,11 @@ jobs:
           # Create Cmfive container
           echo "Starting Cmfive"
           docker run --name cmfive -d -p 3000:80 \
-            -v ${{ github.workspace }}/core/system:/var/www/html/system \
-            -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php \
-            -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test \
-            -v ${{ github.workspace }}/boilerplate/storage:/var/www/html/storage \
+            -v ${{ github.workspace }}/core/system:/var/www/html/system:rw \
+            -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php:rw \
+            -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test:rw \
+            -v ${{ github.workspace }}/boilerplate/storage:/var/www/html/storage:rw \
             ghcr.io/2pisoftware/cmfive:develop
-
-          # Install core
-          docker exec -u cmfive cmfive sh -c "chmod -R ugo=rwX . && php cmfive.php core install"
 
           # Wait for cmfive healthcheck to be healthy
           echo "Waiting for Cmfive to start"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
 
       - name: "Run admin module tests"
         run: |
-            sudo chmod 777 -R system/modules/admin/install/migrations/
+            sudo chmod ugo=rwX -R core/system/modules/admin/install/migrations/
             cd boilerplate/test/playwright
             npm run build
             npm run test --module="admin" --reporter="github"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
       # Run Unit Tests
       - name: "Run unit tests"
         run: |
-          chmod -R ug=rwX boilerplate/test/Codeception/
+          docker exec -u root cmfive chmod -R ug=rwX /var/www/html/test/Codeception/
           docker exec -u cmfive cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php tests unit all; exit \$?"
           if [ $? -gt 0 ]; then
             echo "Admin module tests failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,11 @@ jobs:
         run: |
           # Install packages required for the tests
           docker exec -u root -t cmfive sh -c \
-            "apk add --no-cache php81-dom php81-xmlwriter php81-tokenizer";
+            "apk add --no-cache php81-dom php81-xmlwriter php81-tokenizer php81-ctype";
+
+          # Install phpunit
+          docker exec -u root -t cmfive sh -c \
+            "cd /usr/local/bin && wget -O phpunit https://phar.phpunit.de/phpunit-10.phar && chmod +x phpunit";
 
           # Change owner of the test directory
           docker exec -u root -t cmfive sh -c \

--- a/system/modules/admin/install/migrations/20240223154128-AdminMigration0cbh0j_TestMigration.php
+++ b/system/modules/admin/install/migrations/20240223154128-AdminMigration0cbh0j_TestMigration.php
@@ -1,0 +1,34 @@
+<?php
+
+class AdminMigration0cbh0j_TestMigration extends CmfiveMigration
+{
+    public function up()
+    {
+        // UP
+        $column = parent::Column();
+        $column->setName('id')
+                ->setType('biginteger')
+                ->setIdentity(true);
+
+    }
+
+    public function down()
+    {
+        // DOWN
+    }
+
+    public function preText()
+    {
+        return null;
+    }
+
+    public function postText()
+    {
+        return null;
+    }
+
+    public function description()
+    {
+        return null;
+    }
+}

--- a/system/web.php
+++ b/system/web.php
@@ -997,7 +997,9 @@ class Web
                             Config::enableSandbox();
                             include($searchingDir . '/config.php');
                             $include_path = $searchingDir . '/config.php';
-                            include(ROOT_PATH . '/config.php');
+                            if (file_exists(ROOT_PATH . "/config.php")) {
+                                require ROOT_PATH . "/config.php";
+                            }
 
                             if (Config::get("{$item}.active") === true) {
                                 // Need to reset sandbox content to remove inclusion of project config


### PR DESCRIPTION
Fixes warning when running `php cmfive.php install core` without a config.php. This is happening because the cmfive image is baking in dependencies before a config.php is defined.

Change is based on these lines a little further back in the file:
https://github.com/2pisoftware/cmfive-core/blob/bbcf87e593fb0ad2cb9aa44148e3b3a77b1031b3/system/web.php#L968-L970

The warning:
https://github.com/2pisoftware/cmfive-boilerplate/actions/runs/7984326969/job/21800985159#step:7:269