### PR TITLE
Manually navigating to add timelog button instead of using helper fun…

### DIFF
--- a/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
+++ b/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
@@ -36,7 +36,16 @@ export class TimelogHelper  {
             await page.getByRole("link", {name: taskName, exact: true}).click();
         }
 
-        await CmfiveHelper.clickCmfiveNavbar(page, "Timelog", "Add Timelog");
+        // manually adding navigation due to Add timelog not being a link
+        const navbarCategory = page.locator("#topnav_timelog");
+        const bootstrap5 = await CmfiveHelper.isBootstrap5(page);
+        if (bootstrap5) {
+            await navbarCategory.click();
+        } else { // Foundation
+            await navbarCategory.hover();
+        }
+
+        await navbarCategory.getByText('Add Timelog').click();
         await page.waitForSelector("#cmfive-modal", {state: "visible"});
 
         await CmfiveHelper.fillDatePicker(page, "Date Required", "date_start", date);


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [ ] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
Due to Add Timelog triggering a modal window it isn't technically a link, just manually navigating as its a special case

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: