### PR TITLE
Fix CI for new cmfive docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
           CORE_BRANCH: "${{ github.event.pull_request.head.ref }}"
         run: |
           # Link system dir
-          ln -s {{ github.workspace }}/core/system {{ github.workspace }}/boilerplate/system
+          cd boilerplate
+          ln -s ../core/system system
 
           # Change owner
           sudo chown -R 1000:1000 .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,9 @@ jobs:
       matrix:
         node_version: [18, 20]
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          path: core
+      ## NOTE: Current branch of cmfive-core will be used on the cmfive container
 
+      # Checkout the boilerplate
       - name: Checkout Boilerplate
         uses: actions/checkout@v4
         with:
@@ -78,6 +76,8 @@ jobs:
           docker pull mysql:8
 
       - name: Start containers
+        env:
+          CORE_BRANCH: "${{ github.event.pull_request.head.ref }}"
         run: |
           # Change owner
           sudo chown -R 1000:1000 .
@@ -124,7 +124,6 @@ jobs:
           echo "Starting Cmfive"
           docker run --name cmfive -d -p 3000:80 \
             -v /tmp/.composer:/home/cmfive/.composer/:rw \
-            -v ${{ github.workspace }}/core/system:/var/www/html/system:rw \
             -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php:rw \
             -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test:rw \
             -v ${{ github.workspace }}/boilerplate/storage:/var/www/html/storage:rw \
@@ -132,6 +131,7 @@ jobs:
             -e DB_USERNAME=cmfive_test \
             -e DB_PASSWORD=cmfive_test \
             -e DB_DATABASE=cmfive_test \
+            -e CMFIVE_CORE_BRANCH=$CORE_BRANCH
             --network=cmfive \
             ghcr.io/2pisoftware/cmfive:develop
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
       ## NOTE: Current branch of cmfive-core will be used on the cmfive container
       ## See the `CORE_BRANCH` environment variable in the `Start containers` step
 
+      # Checkout current commit
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: core
+
       # Checkout the boilerplate
       - name: Checkout Boilerplate
         uses: actions/checkout@v4
@@ -74,6 +80,9 @@ jobs:
         env:
           CORE_BRANCH: "${{ github.event.pull_request.head.ref }}"
         run: |
+          # Link system dir
+          ln -s {{ github.workspace }}/core/system {{ github.workspace }}/boilerplate/system
+
           # Change owner
           sudo chown -R 1000:1000 .
 
@@ -116,6 +125,7 @@ jobs:
             -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php:rw \
             -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test:rw \
             -v ${{ github.workspace }}/boilerplate/storage:/var/www/html/storage:rw \
+            -v system:/var/www/html/system:rw \
             -e DB_HOST=mysql-8 \
             -e DB_USERNAME=cmfive_test \
             -e DB_PASSWORD=cmfive_test \
@@ -123,6 +133,7 @@ jobs:
             -e CMFIVE_CORE_BRANCH=$CORE_BRANCH \
             --network=cmfive \
             ghcr.io/2pisoftware/cmfive:develop
+          # Note: system is mounted to a volume to avoid conflicts with the symlink
 
           # Wait for cmfive healthcheck to be healthy
           echo "Waiting for Cmfive to start"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,9 +138,13 @@ jobs:
 
       - name: Compile the theme
         run: |
-          cd boilerplate/system/templates/base
+          # Copy the theme from the docker container
+          docker cp cmfive:/var/www/html/system/templates/base /tmp/cmfive-theme
+          cd /tmp/cmfive-theme
           npm ci || npm install
           npm run production
+          # Copy the compiled theme back to the docker container
+          docker cp /tmp/cmfive-theme/. cmfive:/var/www/html/system/templates/base
 
       # Pre-requisites Prepare Cmfive Environment
       - name: Setup cmfive Test Environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
             -e DB_USERNAME=cmfive_test \
             -e DB_PASSWORD=cmfive_test \
             -e DB_DATABASE=cmfive_test \
-            -e CMFIVE_CORE_BRANCH=$CORE_BRANCH
+            -e CMFIVE_CORE_BRANCH=$CORE_BRANCH \
             --network=cmfive \
             ghcr.io/2pisoftware/cmfive:develop
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,36 +43,148 @@ jobs:
       matrix:
         node_version: [18, 20]
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: core
+
+      - name: Checkout Boilerplate
+        uses: actions/checkout@v4
         with:
           repository: '2pisoftware/cmfive-boilerplate'
           ref: 'develop'
+          path: boilerplate
+
+      # Define cache for .composer
+      - name: Cache .composer
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            /tmp/.composer
+            ${{ github.workspace }}/boilerplate/composer
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+
+      - name: Compile the theme
+        run: |
+          cd core/system/templates/base
+          npm ci || npm install
+          npm run production
 
       # Pre-requisites Prepare Cmfive Environment
+      - name: Pull Docker images
+        run: |
+          docker pull ghcr.io/2pisoftware/cmfive:develop
+          docker pull mysql:8
+
       - name: Start containers
         run: |
-          cp .codepipeline/test_agent/configs/test_agent-config.php config.php
-          docker compose -f docker-compose.yml up --build -d --wait --wait-timeout 120
-          
+          # Change owner
+          sudo chown -R 1000:1000 .
+
+          echo "Linking core/system to boilerplate/system"
+          cd boilerplate
+          sudo ln -s ../core/system system 
+          cd ..
+          ls -la boilerplate/system
+
+          # Create docker network
+          echo "Setting up docker"
+          docker network create cmfive
+
+          # Create MySQL 8 container
+          echo "Starting MySQL 8"
+          docker run --name mysql-8 -d -p 3306:3306 \
+            -e MYSQL_ROOT_PASSWORD=root \
+            -e MYSQL_DATABASE=cmfive_test \
+            -e MYSQL_USER=cmfive_test \
+            -e MYSQL_PASSWORD=cmfive_test \
+            --network=cmfive \
+            mysql:8
+
+          # Wait for MySQL to start
+          echo "Waiting for MySQL to start"
+          time=0
+          while ! docker exec mysql-8 mysqladmin ping -ucmfive_test -pcmfive_test --silent; do
+            sleep 1
+            time=$((time+1))
+            if [ $time -gt 60 ]; then
+              echo "MySQL failed to start"
+              exit 1
+            fi
+          done
+
+          # Get .composer dir ready
+          if [ ! -d /tmp/.composer ]; then
+            mkdir /tmp/.composer
+          fi
+          chmod -R ugo=rwX /tmp/.composer
+
+          # Create Cmfive container
+          echo "Starting Cmfive"
+          docker run --name cmfive -d -p 3000:80 \
+            -v /tmp/.composer:/home/cmfive/.composer/:rw \
+            -v ${{ github.workspace }}/core/system:/var/www/html/system:rw \
+            -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php:rw \
+            -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test:rw \
+            -v ${{ github.workspace }}/boilerplate/storage:/var/www/html/storage:rw \
+            -e DB_HOST=mysql-8 \
+            -e DB_USERNAME=cmfive_test \
+            -e DB_PASSWORD=cmfive_test \
+            -e DB_DATABASE=cmfive_test \
+            --network=cmfive \
+            ghcr.io/2pisoftware/cmfive:develop
+
+          # Wait for cmfive healthcheck to be healthy
+          echo "Waiting for Cmfive to start"
+          time=0
+          while [ "$(docker inspect -f '{{.State.Health.Status}}' cmfive)" != "healthy" ]; do
+            sleep 1
+            time=$((time+1))
+            if [ $time -gt 60 ]; then
+              echo "Cmfive failed to start"
+              exit 1
+            fi
+          done
+
       # Pre-requisites Prepare Cmfive Environment
       - name: Setup cmfive Test Environment
         run: |
-            echo DBCreate 
-            docker exec -t mysql-8 bash -c "mysql -h 127.0.0.1 -u'root' -p'root' --execute \"CREATE DATABASE cmfive_test; CREATE USER cmfive_test@'%' IDENTIFIED BY 'cmfive_test'; GRANT ALL PRIVILEGES ON cmfive_test.* TO cmfive_test@'%'; GRANT PROCESS ON *.* TO cmfive_test@'%'; FLUSH PRIVILEGES;\""
-            docker exec -t cmfive bash -c "chmod -R 777 ./*"
+          docker exec -t cmfive sh -c "chmod -R ugo=rwX /var/www/html*"
 
       - name: Inject configs into cmfive Test Environment
         run: |
           echo "Inheriting test_agent config from PIPELINE"
-          echo 'Config::append("tests", ["testrunner" => "ENABLED"]);' >> config.php
+
+          # Define extra config
+          CONFIG='
+          Config::append(\"tests\", [\"testrunner\" => \"ENABLED\"]);
+          '
+
+          # Write extra config to cmfive container
+          docker exec -t cmfive sh -c "echo \"$CONFIG\" >> /var/www/html/config.php"
 
       - name: Prepare cmfive Test Backend
         run: |
-          docker exec cmfive bash -c "cd ./test/ && sh ./.install/install.sh && chmod -R 777 /var/www/html/test/Codeception/tests"
+          # Install packages required for the tests
+          docker exec -u root -t cmfive sh -c \
+            "apk add --no-cache php81-dom php81-xmlwriter php81-tokenizer php81-ctype mysql-client mariadb-connector-c-dev";
+
+          # Install phpunit 8
+          docker exec -u root cmfive sh -c \
+            "cd /usr/local/bin && curl -L https://phar.phpunit.de/phpunit-8.phar -o phpunit && chmod +x phpunit && chmod 777 .";
+
+          # Change owner of the test directory
+          docker exec -u root -t cmfive sh -c \
+            "chown -R cmfive:cmfive /var/www/html/test";
+
+          # Install Codeception
+          docker exec -u cmfive cmfive sh -c \
+            "cd /var/www/html/test/ && sh ./.install/install.sh"
 
       - name: Prepare cmfive Test DB
         run: |
-          docker exec -t cmfive bash -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php testDB setup; exit \$?";
+          docker exec -t cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=root DB_PASSWORD=root DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php testDB setup; exit \$?";
         
       # Build new layout
       - uses: actions/setup-node@v4
@@ -82,25 +194,31 @@ jobs:
       # Run Unit Tests
       - name: "Run unit tests"
         run: |
-          docker exec cmfive bash -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php tests unit all; exit \$?"
+          docker exec -u root cmfive chmod -R ugo=rwX /var/www/html/test/
+          docker exec -u cmfive cmfive sh -c "DB_HOST=mysql-8 DB_USERNAME=cmfive_test DB_PASSWORD=cmfive_test DB_DATABASE=cmfive_test DB_PORT=3306 php cmfive.php tests unit all; exit \$?"
           if [ $? -gt 0 ]; then
             echo "Admin module tests failed"
           fi
         # Setup playwright
       - name: Setup Playwright
         run: |
-          cd test/playwright
+          # Link system so it can find tests
+          echo "Contents of core/system"
+          ls -la core/system/
+
+          echo "Installing Playwright"
+          cd boilerplate/test/playwright
           npm ci
           npx playwright install --with-deps
       # Run Acceptance Tests
       - name: "Confirm Codeception setup"
         run: |        
-          docker exec cmfive bash -c "ls -lah -R /var/www/html/test/Codeception/tests && cat /var/www/html/test/Codeception/*.yml && cat /var/www/html/test/Codeception/tests/*.yml"
+          docker exec cmfive sh -c "ls -lah -R /var/www/html/test/Codeception/tests && cat /var/www/html/test/Codeception/*.yml && cat /var/www/html/test/Codeception/tests/*.yml"
 
       - name: "Run admin module tests"
         run: |
-            sudo chmod 777 -R system/modules/admin/install/migrations/
-            cd test/playwright
+            sudo chmod ugo=rwX -R boilerplate/system/modules/admin/install/migrations/
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="admin" --reporter="github"
             if [ $? -gt 0 ]; then
@@ -108,7 +226,7 @@ jobs:
             fi
       - name: "Run channel module tests"
         run: |
-            cd test/playwright
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="channel" --reporter="github"
             if [ $? -gt 0 ]; then
@@ -116,7 +234,7 @@ jobs:
             fi
       - name: "Run form module tests"
         run: |
-            cd test/playwright
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="form" --reporter="github"
             if [ $? -gt 0 ]; then
@@ -124,7 +242,7 @@ jobs:
             fi
       - name: "Run report module tests"
         run: |
-          cd test/playwright
+          cd boilerplate/test/playwright
           npm run build
           npm run test --module="report" --reporter="github"
           if [ $? -gt 0 ]; then
@@ -132,7 +250,7 @@ jobs:
           fi
       - name: "Run tag module tests"
         run: |
-            cd test/playwright
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="tag" --reporter="github"
             if [ $? -gt 0 ]; then
@@ -140,7 +258,7 @@ jobs:
             fi
       - name: "Run task module tests"
         run: |
-            cd test/playwright
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="task" --reporter="github"
             if [ $? -gt 0 ]; then
@@ -148,18 +266,26 @@ jobs:
             fi
       - name: "Run timelog module tests"
         run: |
-            cd test/playwright
+            cd boilerplate/test/playwright
             npm run build
             npm run test --module="timelog" --reporter="github"
             if [ $? -gt 0 ]; then
                 echo "Timelog module tests failed"
             fi
 
+      - name: Get container logs
+        if: failure()
+        run: |
+          docker logs cmfive
+
       - name: Stop containers
         # the containers should be stopped regardless of 
         # the test result
         if: always()
-        run: docker-compose down
+        run: |
+          docker rm cmfive -f
+          docker rm mysql-8 -f
+          docker network rm cmfive
 
       # Store Test Results
       - name: Test results
@@ -168,8 +294,9 @@ jobs:
         with:
           name: test-output-${{matrix.node_version}}
           path: |
-            test/Codeception/tests/_output/
-            storage/log/
-            test/playwright/test-results/
-            test/playwright/playwright-report/
+            boilerplate/test/Codeception/tests/_output/
+            boilerplate/storage/log/
+            boilerplate/test/playwright/test-results/
+            boilerplate/test/playwright/playwright-report/
           retention-days: 5
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           if [ $? -gt 0 ]; then
             echo "Admin module tests failed"
           fi
-        # Setup playwright
+      # Setup playwright
       - name: Setup Playwright
         run: |
           echo "Installing Playwright"
@@ -212,7 +212,7 @@ jobs:
 
       - name: "Run admin module tests"
         run: |
-            sudo chmod ugo=rwX -R boilerplate/system/modules/admin/install/migrations/
+            docker exec -u root cmfive sh -c "chmod ugo=rwX -R /var/www/html/system/modules/admin/install/migrations/"
             cd boilerplate/test/playwright
             npm run build
             npm run test --module="admin" --reporter="github"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         node_version: [18, 20]
     steps:
       ## NOTE: Current branch of cmfive-core will be used on the cmfive container
+      ## See the `CORE_BRANCH` environment variable in the `Start containers` step
 
       # Checkout the boilerplate
       - name: Checkout Boilerplate
@@ -63,12 +64,6 @@ jobs:
             ${{ github.workspace }}/boilerplate/composer
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
 
-      - name: Compile the theme
-        run: |
-          cd core/system/templates/base
-          npm ci || npm install
-          npm run production
-
       # Pre-requisites Prepare Cmfive Environment
       - name: Pull Docker images
         run: |
@@ -81,12 +76,6 @@ jobs:
         run: |
           # Change owner
           sudo chown -R 1000:1000 .
-
-          echo "Linking core/system to boilerplate/system"
-          cd boilerplate
-          sudo ln -s ../core/system system 
-          cd ..
-          ls -la boilerplate/system
 
           # Create docker network
           echo "Setting up docker"
@@ -147,6 +136,12 @@ jobs:
             fi
           done
 
+      - name: Compile the theme
+        run: |
+          cd boilerplate/system/templates/base
+          npm ci || npm install
+          npm run production
+
       # Pre-requisites Prepare Cmfive Environment
       - name: Setup cmfive Test Environment
         run: |
@@ -202,10 +197,6 @@ jobs:
         # Setup playwright
       - name: Setup Playwright
         run: |
-          # Link system so it can find tests
-          echo "Contents of core/system"
-          ls -la core/system/
-
           echo "Installing Playwright"
           cd boilerplate/test/playwright
           npm ci

--- a/system/modules/admin/actions/templates/edit.php
+++ b/system/modules/admin/actions/templates/edit.php
@@ -27,7 +27,7 @@ function edit_GET(Web $w)
 				'label' => 'Active',
 				"class" => "",
 				"checked" => $t->is_active ? $t->is_active : null
-			]))// ->setAttribute("is_active", $t->is_active) //["Active", "checkbox", "is_active", $t->is_active]
+			])) // ->setAttribute("is_active", $t->is_active) //["Active", "checkbox", "is_active", $t->is_active]
 		],
 		[
 			(new \Html\Form\InputField\Text([
@@ -71,7 +71,7 @@ function edit_GET(Web $w)
 			(new \Html\Cmfive\CodeMirrorEditor([
 				"id|name" => "template_body",
 				"value" => $t->template_body,
-			]))//->addToConfig(['extensions' => ['basicSetup'], 'parent' => 'template_body']) //["", "textarea", "template_body", $t->template_body, 60, 100, "codemirror"]
+			])) //->addToConfig(['extensions' => ['basicSetup'], 'parent' => 'template_body']) //["", "textarea", "template_body", $t->template_body, 60, 100, "codemirror"]
 		]
 	];
 
@@ -85,7 +85,7 @@ function edit_GET(Web $w)
 				"value" => $t->test_title_json,
 				"maxlength" => 500
 			])) //["", "textarea", "test_title_json", $t->test_title_json, 100, 5, false]]
-		] 
+		]
 	];
 	$newForm["Body Data"] = [
 		[
@@ -94,7 +94,7 @@ function edit_GET(Web $w)
 				"value" => $t->test_body_json,
 				"maxlength" => 2000
 			])) // ["", "textarea", "test_body_json", $t->test_body_json, 100, 20, false]]
-		] 
+		]
 	];
 
 	$w->ctx("testdataform", HtmlBootstrap5::multiColForm($newForm, $w->localUrl('/admin-templates/edit/' . $t->id)));
@@ -106,7 +106,8 @@ function edit_POST(Web $w)
 	$p = $w->pathMatch("id");
 	$t = $p["id"] ? TemplateService::getInstance($w)->getTemplate($p['id']) : new Template($w);
 	$t->fill($_POST);
-    $t->template_body = json_decode($_POST['template_body']);
+	$encoded_template_body = $_POST['template_body'] ?? '';
+	$t->template_body = json_decode($encoded_template_body);
 
 	// Set is active if saving is originating from the first page
 	if (isset($_POST["title"]) && isset($_POST["module"]) && isset($_POST["category"])) {

--- a/system/modules/admin/tests/acceptance/playwright/admin.test.ts
+++ b/system/modules/admin/tests/acceptance/playwright/admin.test.ts
@@ -167,8 +167,10 @@ test("Test that Cmfive Admin can create/run/rollback migrations", async ({ page 
     // test that migration can be run/rolled back from "Individual" migrations tab
     await page.getByRole("link", { name: "Individual" }).click();
 
+    const migrationsCount = await page.getByRole('button', {name: 'Migrate to here'}).count();
+    const plural = migrationsCount == 1 ? " has" : "s have";
     await CmfiveHelper.getRowByText(page, "Admin"+migration).getByRole("button", { name: "Migrate to here" }).click();
-    await expect(page.getByText("1 migration has run.")).toBeVisible();
+    await expect(page.getByText(`${migrationsCount} migration${plural} run.`)).toBeVisible();
 
     await CmfiveHelper.getRowByText(page, "Admin" + migration).getByRole("button", { name: "Rollback to here" }).click();
     await expect(page.getByText("1 migration has rolled back")).toBeVisible();

--- a/system/modules/admin/tests/playwright/admin.test.ts
+++ b/system/modules/admin/tests/playwright/admin.test.ts
@@ -1,7 +1,0 @@
-import { test, expect } from '@playwright/test';
-import { PlaywrightHelper } from './helpers';
-
-test('test admin page', async ({ page }) => {
-    await PlaywrightHelper.login(page, 'admin', 'admin');
-    
-});

--- a/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
+++ b/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
@@ -36,7 +36,16 @@ export class TimelogHelper  {
             await page.getByRole("link", {name: taskName, exact: true}).click();
         }
 
-        await CmfiveHelper.clickCmfiveNavbar(page, "Timelog", "Add Timelog");
+        // manually adding navigation due to Add timelog not being a link
+        const navbarCategory = page.locator("#topnav_timelog");
+        const bootstrap5 = await CmfiveHelper.isBootstrap5(page);
+        if (bootstrap5) {
+            await navbarCategory.click();
+        } else { // Foundation
+            await navbarCategory.hover();
+        }
+
+        await navbarCategory.getByText('Add Timelog').click();
         await page.waitForSelector("#cmfive-modal", {state: "visible"});
 
         await CmfiveHelper.fillDatePicker(page, "Date Required", "date_start", date);


### PR DESCRIPTION
This fixes the cmfive-core CI so that it passes for the new cmfive image.

Changes to note:

- Each step adapted for minor differences for alpine
- Cmfive and root users specified for each docker exec step
- Boilerplate develop branch is checked out and used in the test
- Current cmfive-core commit is checked out and used in the test
- Dependency on boilerplate docker-compose was dropped, now uses plain docker (reason is so that the CI defines its own method)
- Gets container logs when there's a failure
- Composer module caching (may not be working properly yet)

This has been thoroughly tested, ~some playwright tests aren't passing at the moment, however without them the workflow passes~.