### PR TITLE
Fix/admin test

### DIFF
--- a/system/modules/admin/actions/templates/edit.php
+++ b/system/modules/admin/actions/templates/edit.php
@@ -27,7 +27,7 @@ function edit_GET(Web $w)
 				'label' => 'Active',
 				"class" => "",
 				"checked" => $t->is_active ? $t->is_active : null
-			]))// ->setAttribute("is_active", $t->is_active) //["Active", "checkbox", "is_active", $t->is_active]
+			])) // ->setAttribute("is_active", $t->is_active) //["Active", "checkbox", "is_active", $t->is_active]
 		],
 		[
 			(new \Html\Form\InputField\Text([
@@ -71,7 +71,7 @@ function edit_GET(Web $w)
 			(new \Html\Cmfive\CodeMirrorEditor([
 				"id|name" => "template_body",
 				"value" => $t->template_body,
-			]))//->addToConfig(['extensions' => ['basicSetup'], 'parent' => 'template_body']) //["", "textarea", "template_body", $t->template_body, 60, 100, "codemirror"]
+			])) //->addToConfig(['extensions' => ['basicSetup'], 'parent' => 'template_body']) //["", "textarea", "template_body", $t->template_body, 60, 100, "codemirror"]
 		]
 	];
 
@@ -85,7 +85,7 @@ function edit_GET(Web $w)
 				"value" => $t->test_title_json,
 				"maxlength" => 500
 			])) //["", "textarea", "test_title_json", $t->test_title_json, 100, 5, false]]
-		] 
+		]
 	];
 	$newForm["Body Data"] = [
 		[
@@ -94,7 +94,7 @@ function edit_GET(Web $w)
 				"value" => $t->test_body_json,
 				"maxlength" => 2000
 			])) // ["", "textarea", "test_body_json", $t->test_body_json, 100, 20, false]]
-		] 
+		]
 	];
 
 	$w->ctx("testdataform", HtmlBootstrap5::multiColForm($newForm, $w->localUrl('/admin-templates/edit/' . $t->id)));
@@ -106,7 +106,8 @@ function edit_POST(Web $w)
 	$p = $w->pathMatch("id");
 	$t = $p["id"] ? TemplateService::getInstance($w)->getTemplate($p['id']) : new Template($w);
 	$t->fill($_POST);
-    $t->template_body = json_decode($_POST['template_body']);
+	$encoded_template_body = $_POST['template_body'] ?? '';
+	$t->template_body = json_decode($encoded_template_body);
 
 	// Set is active if saving is originating from the first page
 	if (isset($_POST["title"]) && isset($_POST["module"]) && isset($_POST["category"])) {

--- a/system/modules/admin/tests/acceptance/playwright/admin.test.ts
+++ b/system/modules/admin/tests/acceptance/playwright/admin.test.ts
@@ -167,8 +167,10 @@ test("Test that Cmfive Admin can create/run/rollback migrations", async ({ page 
     // test that migration can be run/rolled back from "Individual" migrations tab
     await page.getByRole("link", { name: "Individual" }).click();
 
+    const migrationsCount = await page.getByRole('button', {name: 'Migrate to here'}).count();
+    const plural = migrationsCount == 1 ? " has" : "s have";
     await CmfiveHelper.getRowByText(page, "Admin"+migration).getByRole("button", { name: "Migrate to here" }).click();
-    await expect(page.getByText("1 migration has run.")).toBeVisible();
+    await expect(page.getByText(`${migrationsCount} migration${plural} run.`)).toBeVisible();
 
     await CmfiveHelper.getRowByText(page, "Admin" + migration).getByRole("button", { name: "Rollback to here" }).click();
     await expect(page.getByText("1 migration has rolled back")).toBeVisible();

--- a/system/modules/admin/tests/playwright/admin.test.ts
+++ b/system/modules/admin/tests/playwright/admin.test.ts
@@ -1,7 +1,0 @@
-import { test, expect } from '@playwright/test';
-import { PlaywrightHelper } from './helpers';
-
-test('test admin page', async ({ page }) => {
-    await PlaywrightHelper.login(page, 'admin', 'admin');
-    
-});


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [ ] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
Fixes to admin and timelog playwright tests causing them to fail.
They are now more reliable and less flaky

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: