### PR TITLE
Fix bootstrap template search modal

### DIFF
--- a/system/modules/search/templates/index.tpl.php
+++ b/system/modules/search/templates/index.tpl.php
@@ -1,39 +1,40 @@
 <div>
-    <h3 class="subheading columns large-6">Search</h3>
-    <span class="columns large-6" style="text-align: right;">
-        <p style="font-size: 12px;">
-        <strong>Note:</strong> Search terms must contain minimum 3 characters.
-        <br>
-        <strong>Tip:</strong> To search by Id, use 'id##' eg. id5.
-        </p>
-    </span>
+	<h3 class="subheading columns large-6">Search</h3>
+	<span class="columns large-6" style="text-align: right;">
+		<p style="font-size: 12px;">
+			<strong>Note:</strong> Search terms must contain minimum 3 characters.
+			<br>
+			<strong>Tip:</strong> To search by Id, use 'id##' eg. id5.
+		</p>
+	</span>
 </div>
 <hr>
 <div class="row-fluid">
-<!--    <form action="<?php // echo $webroot; ?>/search/results" method="GET">-->
-    <form id="search_form" class="clearfix">
-        <input type="hidden" name="<?php echo CSRF::getTokenID(); ?>" value="<?php echo CSRF::getTokenValue(); ?>" />
-        <div class="row-fluid">
-            <div class="small-12 medium-6 columns">
-                <input class="input-large" type="text" name="q" id="q" autofocus/>
-            </div>
+	<!--    <form action="<?php // echo $webroot; 
+							?>/search/results" method="GET">-->
+	<form id="search_form" class="clearfix">
+		<input type="hidden" name="<?php echo CSRF::getTokenID(); ?>" value="<?php echo CSRF::getTokenValue(); ?>" />
+		<div class="row-fluid">
+			<div class="small-12 medium-6 columns">
+				<input class="input-large" type="text" name="q" id="q" autofocus />
+			</div>
 			<div class="small-12 medium-2 columns">
-                <?php echo Html::select("idx", $indexes); ?>
-            </div>
-            <div class="small-12 medium-2 columns">
-                <?php echo Html::select("tags", $tags); ?>
-            </div>
-            <div class="small-12 medium-2 columns">
-                <button class="button tiny small-12" type="submit">Go</button>
-            </div>
-        </div>
-    </form>
+				<?php echo Html::select("idx", $indexes); ?>
+			</div>
+			<div class="small-12 medium-2 columns">
+				<?php echo Html::select("tags", $tags); ?>
+			</div>
+			<div class="small-12 medium-2 columns">
+				<button class="button tiny small-12" type="submit">Go</button>
+			</div>
+		</div>
+	</form>
 
 
 </div>
 
-<div id="search_message" class="row hide">
-    <div data-alert class="alert-box warning" id="message_box"></div>
+<div id="search_message" class="row">
+	<div data-alert style="margin-top: 1rem" class="alert-box warning" id="message_box"></div>
 </div>
 
 <div id="result" class="row" style="display: none;">
@@ -41,34 +42,41 @@
 </div>
 
 <script>
-    $("#search_form").submit(function(event) {
-        event.preventDefault();
-        $("#search_message").hide();
-        $("#result").hide();
+	const setError = (str) => {
+		if (!str) {
+			document.querySelector("#search_message").style.display = "none";
+			document.querySelector("#result").style.display = "block";
+			return;
+		}
 
-        var data = $("#search_form").serialize();
+		document.querySelector("#message_box").innerText = str;
+		document.querySelector("#search_message").style.display = "block";
+		document.querySelector("#result").style.display = "none";
+	}
 
-        $.getJSON("/search/results", data,
-            function(response) {
-                if (response.success === false) {
-                    $("#message_box").html(response.data);
-                    $("#search_message").show();
-                } else {
-                    var text_data = "<span style='padding-left: 20px;'>No results found</span>";
-                    if (response.data) {
-                        text_data = response.data;
-                    }
-                    $("#result").html(text_data).delay(100).fadeIn();
-                }
-            },
-            function(response) {
-                $("#message_box").html("Failed to receive a response from search");
-                $("#search_message").show();
-            }
-        );
+	document.querySelector("#search_form").addEventListener("submit", async function(event) {
+		event.preventDefault();
 
-        return false;
-    });
+		setError(false);
 
+		const form = new FormData(event.target);
+		const body = new URLSearchParams(form);
+
+		try {
+			const response = await fetch(`/search/results?` + body.toString());
+
+			const json = await response.json();
+
+			if (!json.success)
+				return setError(json.data);
+
+			document.querySelector("#result").innerHTML =
+				json.data || `<span style="padding-left: 20px;">No results found</span>`;
+		} catch (e) {
+			setError(`Failed to receive a response from search`);
+		}
+
+		return false;
+	});
 </script>
 <br>

--- a/system/templates/base/src/js/app.ts
+++ b/system/templates/base/src/js/app.ts
@@ -1,6 +1,6 @@
 // src/app.ts
 import { AlertAdaptation, DropdownAdaptation, FavouritesAdaptation, TabAdaptation, TableAdaptation } from './adaptations';
-import { QuillEditor, InputWithOther, MultiFileUpload, MultiSelect, Overlay, CodeMirror } from './components';
+import { CodeMirror, InputWithOther, MultiFileUpload, MultiSelect, Overlay, QuillEditor } from './components';
 
 import { Modal, Toast, Tooltip } from 'bootstrap';
 
@@ -97,6 +97,13 @@ class Cmfive {
             return response.text()
         }).then((content) => {
             modalContent.innerHTML = content + modalContent.innerHTML;
+
+			// https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#security_considerations
+			// Appending scripts to the DOM via innerHTML is not meant to execute them for security purposes
+			// Unfortunately, various modals however contian script tags we need to execute
+			modalContent.querySelectorAll("script").forEach(x => {
+				eval(x.innerHTML);
+			})
     
             // Rebind elements for modal
             Cmfive.ready(modalContent);

--- a/system/templates/base/src/scss/cmfive/_forms.scss
+++ b/system/templates/base/src/scss/cmfive/_forms.scss
@@ -50,4 +50,8 @@ form {
             width: 100%;
         }
     }
+
+	input.input-large {
+		width: 100%;
+	}
 }

--- a/system/templates/layout-bootstrap-5.tpl.php
+++ b/system/templates/layout-bootstrap-5.tpl.php
@@ -12,8 +12,10 @@ $theme_setting = AuthService::getInstance($w)->getSettingByKey('bs5-theme');
     <?php
     CmfiveStyleComponentRegister::registerComponent('app', new CmfiveStyleComponent("/system/templates/base/dist/app.css"));
     CmfiveScriptComponentRegister::registerComponent('app', new CmfiveScriptComponent("/system/templates/base/dist/app.js"));
+    $w->enqueueScript(["name" => "jquery.js", "uri" => "/system/templates/js/foundation-5.5.0/js/vendor/jquery.js", "weight" => 1000]);
 
     $w->outputStyles();
+	$w->outputScripts();
     ?>
     <!-- backwards compat -->
     <script src="/system/templates/base/node_modules/vue3/dist/vue.global.prod.js"></script>

--- a/system/templates/layout-bootstrap-5.tpl.php
+++ b/system/templates/layout-bootstrap-5.tpl.php
@@ -12,10 +12,8 @@ $theme_setting = AuthService::getInstance($w)->getSettingByKey('bs5-theme');
     <?php
     CmfiveStyleComponentRegister::registerComponent('app', new CmfiveStyleComponent("/system/templates/base/dist/app.css"));
     CmfiveScriptComponentRegister::registerComponent('app', new CmfiveScriptComponent("/system/templates/base/dist/app.js"));
-    $w->enqueueScript(["name" => "jquery.js", "uri" => "/system/templates/js/foundation-5.5.0/js/vendor/jquery.js", "weight" => 1000]);
 
     $w->outputStyles();
-	$w->outputScripts();
     ?>
     <!-- backwards compat -->
     <script src="/system/templates/base/node_modules/vue3/dist/vue.global.prod.js"></script>


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

I really do not like this solution, but I'm hesitant to make large changes to the codebase for a better solution.
As a security measure, appending scripts via `innerHTML` does not execute them, however many modals contain script tags,
and they are required to execute and do so in the old theme. Something in the new theme prevents this.
The search modal is one that requires it's scripts to execute in order to add the form event listener etc, which wasn't running because of the above.

https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#security_considerations

<!-- List your changes as a dot point list. -->
## Changelog

- Bootstrap theme search query box is now full length, like in old theme
- Search in bootstrap theme now works

<!-- Add any important refs or issues numbers. -->
issues: #288