### PR TITLE
Fixing duplication of timelog entries

### DIFF
--- a/system/modules/timelog/actions/edit.php
+++ b/system/modules/timelog/actions/edit.php
@@ -119,6 +119,14 @@ function edit_POST(Web $w)
         $timelog->user_id = !empty($_POST['user_id']) ? intval($_POST['user_id']) : AuthService::getInstance($w)->user()->id;
     }
 
+    // Check to see if timelog already exists, and remove if duplicate
+    $all_timelogs = TimelogService::getInstance($w)->getTimelogs();
+    foreach ($all_timelogs as $existing_timelog) {
+        if ($existing_timelog->getDateStart() == substr($timelog->dt_start, 0, 10) && $existing_timelog->getTimeStart() == date('H:i', strtotime($timelog->dt_start)+36000)) {
+            $w->error('Duplicate Timelog Deleted', $redirect ?: '/timelog');
+        }
+    }
+    
     // Timelog user_id handled in insert/update
     $timelog->insertOrUpdate();
 

--- a/system/modules/timelog/actions/edit.php
+++ b/system/modules/timelog/actions/edit.php
@@ -121,9 +121,15 @@ function edit_POST(Web $w)
 
     // Check to see if timelog already exists, and remove if duplicate
     $all_timelogs = TimelogService::getInstance($w)->getTimelogs();
+    $all_timelogs_for_user = [];
     foreach ($all_timelogs as $existing_timelog) {
-        if ($existing_timelog->getDateStart() == substr($timelog->dt_start, 0, 10) && $existing_timelog->getTimeStart() == date('H:i', strtotime($timelog->dt_start)+36000)) {
-            $w->error('Duplicate Timelog Deleted', $redirect ?: '/timelog');
+        if ($existing_timelog->user_id == $timelog->user_id) {
+            $all_timelogs_for_user[] = $existing_timelog;
+        }
+    }
+    foreach ($all_timelogs_for_user as $existing_timelog_for_user) {
+        if (gmdate('Y-m-d', strtotime($existing_timelog_for_user->getDateStart() . ' ' . $existing_timelog_for_user->getTimeStart())) == substr($timelog->dt_start, 0, 10) && gmdate('H:i', strtotime($existing_timelog_for_user->getTimeStart())) == substr($timelog->dt_start, 11, 5)) {
+            $w->error('Duplicate Timelog Removed', $redirect ?: '/timelog');
         }
     }
     

--- a/system/modules/timelog/actions/edit.php
+++ b/system/modules/timelog/actions/edit.php
@@ -119,16 +119,16 @@ function edit_POST(Web $w)
         $timelog->user_id = !empty($_POST['user_id']) ? intval($_POST['user_id']) : AuthService::getInstance($w)->user()->id;
     }
 
-    // Check to see if timelog already exists, and remove if duplicate
-    $all_timelogs = TimelogService::getInstance($w)->getTimelogs();
-    $all_timelogs_for_user = [];
-    foreach ($all_timelogs as $existing_timelog) {
+    // Check to see if timelog with same starting time already exists, and remove if duplicate
+    $timelogs_for_task = TimelogService::getInstance($w)->getTimelogsForObject($timelog->getLinkedObject());
+    $timelogs_for_task_and_user = [];
+    foreach ($timelogs_for_task as $existing_timelog) {
         if ($existing_timelog->user_id == $timelog->user_id) {
-            $all_timelogs_for_user[] = $existing_timelog;
+            $all_timelogs_for_task_and_user[] = $existing_timelog;
         }
     }
-    foreach ($all_timelogs_for_user as $existing_timelog_for_user) {
-        if (gmdate('Y-m-d', strtotime($existing_timelog_for_user->getDateStart() . ' ' . $existing_timelog_for_user->getTimeStart())) == substr($timelog->dt_start, 0, 10) && gmdate('H:i', strtotime($existing_timelog_for_user->getTimeStart())) == substr($timelog->dt_start, 11, 5)) {
+    foreach ($all_timelogs_for_task_and_user as $existing_timelog_for_task_and_user) {
+        if (gmdate('Y-m-d', strtotime($existing_timelog_for_task_and_user->getDateStart() . ' ' . $existing_timelog_for_task_and_user->getTimeStart())) == substr($timelog->dt_start, 0, 10) && gmdate('H:i', strtotime($existing_timelog_for_task_and_user->getTimeStart())) == substr($timelog->dt_start, 11, 5)) {
             $w->error('Duplicate Timelog Removed', $redirect ?: '/timelog');
         }
     }

--- a/system/modules/timelog/actions/edit.php
+++ b/system/modules/timelog/actions/edit.php
@@ -124,10 +124,10 @@ function edit_POST(Web $w)
     $timelogs_for_task_and_user = [];
     foreach ($timelogs_for_task as $existing_timelog) {
         if ($existing_timelog->user_id == $timelog->user_id) {
-            $all_timelogs_for_task_and_user[] = $existing_timelog;
+            $timelogs_for_task_and_user[] = $existing_timelog;
         }
     }
-    foreach ($all_timelogs_for_task_and_user as $existing_timelog_for_task_and_user) {
+    foreach ($timelogs_for_task_and_user as $existing_timelog_for_task_and_user) {
         if (gmdate('Y-m-d', strtotime($existing_timelog_for_task_and_user->getDateStart() . ' ' . $existing_timelog_for_task_and_user->getTimeStart())) == substr($timelog->dt_start, 0, 10) && gmdate('H:i', strtotime($existing_timelog_for_task_and_user->getTimeStart())) == substr($timelog->dt_start, 11, 5)) {
             $w->error('Duplicate Timelog Removed', $redirect ?: '/timelog');
         }

--- a/system/modules/timelog/tests/acceptance/playwright/timelog.test.ts
+++ b/system/modules/timelog/tests/acceptance/playwright/timelog.test.ts
@@ -57,3 +57,44 @@ test("You can create a Timelog using Add Timelog" , async ({page}) => {
     await TaskHelper.deleteTask(page, task, taskID);
     await TaskHelper.deleteTaskGroup(page, taskgroup, taskgroupID);
 });
+
+test("Test that duplicate timelogs are deleted" , async ({page}) => {
+    test.setTimeout(GLOBAL_TIMEOUT);
+    CmfiveHelper.acceptDialog(page);
+
+    await CmfiveHelper.login(page, "admin", "admin");
+    
+    const taskgroup = CmfiveHelper.randomID("taskgroup_");
+    const taskgroupID = await TaskHelper.createTaskGroup(page, taskgroup, "Software Development", "OWNER", "OWNER", "OWNER");
+    await TaskHelper.addMemberToTaskgroup(page, taskgroup, taskgroupID, "Admin Admin", "OWNER");
+    await TaskHelper.setDefaultAssignee(page, taskgroup, taskgroupID, "Admin Admin");
+
+    const task = CmfiveHelper.randomID("task_");
+    const taskID = await TaskHelper.createTask(page, task, taskgroup, "Software Development");
+
+    const timelog1 = CmfiveHelper.randomID("timelog_");
+    await TimelogHelper.createTimelog(
+        page,
+        timelog1,
+        task,
+        taskID,
+        DateTime.fromFormat("6/6/2024", "d/M/yyyy"),
+        "1:00",
+        "2:00",
+    );
+    const timelog2 = CmfiveHelper.randomID("timelog_");
+    await TimelogHelper.createTimelog(
+        page,
+        timelog2,
+        task,
+        taskID,
+        DateTime.fromFormat("6/6/2024", "d/M/yyyy"),
+        "1:00",
+        "2:00",
+        true,
+    );
+
+    await TimelogHelper.deleteTimelog(page, timelog1, task, taskID);
+    await TaskHelper.deleteTask(page, task, taskID);
+    await TaskHelper.deleteTaskGroup(page, taskgroup, taskgroupID);
+});

--- a/system/modules/timelog/tests/acceptance/playwright/timelog.test.ts
+++ b/system/modules/timelog/tests/acceptance/playwright/timelog.test.ts
@@ -66,8 +66,8 @@ test("Test that duplicate timelogs are deleted" , async ({page}) => {
     
     const taskgroup = CmfiveHelper.randomID("taskgroup_");
     const taskgroupID = await TaskHelper.createTaskGroup(page, taskgroup, "Software Development", "OWNER", "OWNER", "OWNER");
-    await TaskHelper.addMemberToTaskgroup(page, taskgroup, taskgroupID, "Admin Admin", "OWNER");
-    await TaskHelper.setDefaultAssignee(page, taskgroup, taskgroupID, "Admin Admin");
+    await TaskHelper.addMemberToTaskgroup(page, taskgroup, taskgroupID, "admin admin", "OWNER");
+    await TaskHelper.setDefaultAssignee(page, taskgroup, taskgroupID, "admin admin");
 
     const task = CmfiveHelper.randomID("task_");
     const taskID = await TaskHelper.createTask(page, task, taskgroup, "Software Development");

--- a/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
+++ b/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
@@ -27,7 +27,7 @@ export class TimelogHelper  {
         await expect(page.getByText(timelog)).toBeVisible();
     }
 
-    static async createTimelog(page: Page, timelog: string, taskName: string, taskID: string, date: DateTime, start_time: string, end_time: string)
+    static async createTimelog(page: Page, timelog: string, taskName: string, taskID: string, date: DateTime, start_time: string, end_time: string, check_duplicate: boolean = false)
     {
         if(page.url() != HOST + "/task/edit/" + taskID + "#details") {
             if(page.url() != HOST + "/task/tasklist")
@@ -54,31 +54,17 @@ export class TimelogHelper  {
         await page.getByLabel("Description", {exact: true}).fill(timelog);
         await page.locator("#timelog_edit_form").getByRole("button", { name: "Save" }).click();
 
-        await page.getByRole("link", {name: taskName, exact: true}).first().click();
+        if (check_duplicate) {
+            await expect(page.getByText("Duplicate Timelog Removed")).toBeVisible();
+        }
+        await page.getByRole("link", {name: taskName, exact: false}).first().click();
         await page.getByRole("link", {name: "Time Log"}).click();
         await page.reload();
-        await expect(page.getByText(timelog)).toBeVisible();
-    }
-
-    static async editTimelog(page: Page, timelog: string, taskName: string, taskID: string, date: DateTime, start_time: string, end_time: string)
-    {
-        if(page.url() == HOST + "/task/edit/" + taskID + "#timelog") page.reload();
-        else if(page.url() != HOST + "/task/edit/" + taskID + "#details") {
-            if(page.url() != HOST + "/task/tasklist")
-                await CmfiveHelper.clickCmfiveNavbar(page, "Task", "Task List");
-            
-            await page.getByRole("link", {name: taskName, exact: true}).click();
-            await page.getByRole("link", {name: "Time Log"}).click();
+        if (!check_duplicate) {
+            await expect(page.getByText(timelog)).toBeVisible();
+        } else {
+            await expect(page.getByText(timelog)).toBeHidden();
         }
-
-        await CmfiveHelper.getRowByText(page, timelog).getByRole("button", {name: "Edit"}).click();
-        
-        await CmfiveHelper.fillDatePicker(page, "Date Required", "date_start", date);
-        await page.locator("#time_start").fill(start_time);
-        await page.locator("#time_end").fill(end_time);
-        await page.getByRole("button", {name: "Save"}).click();
-
-        await expect(page.getByText("Timelog saved")).toBeVisible();
     }
 
     static async deleteTimelog(page: Page, timelog: string, taskName: string, taskID: string)

--- a/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
+++ b/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
@@ -67,6 +67,27 @@ export class TimelogHelper  {
         }
     }
 
+    static async editTimelog(page: Page, timelog: string, taskName: string, taskID: string, date: DateTime, start_time: string, end_time: string)
+    {
+        if(page.url() == HOST + "/task/edit/" + taskID + "#timelog") page.reload();
+        else if(page.url() != HOST + "/task/edit/" + taskID + "#details") {
+            if(page.url() != HOST + "/task/tasklist")
+                await CmfiveHelper.clickCmfiveNavbar(page, "Task", "Task List");
+            
+            await page.getByRole("link", {name: taskName, exact: true}).click();
+            await page.getByRole("link", {name: "Time Log"}).click();
+        }
+
+        await CmfiveHelper.getRowByText(page, timelog).getByRole("button", {name: "Edit"}).click();
+        
+        await CmfiveHelper.fillDatePicker(page, "Date Required", "date_start", date);
+        await page.locator("#time_start").fill(start_time);
+        await page.locator("#time_end").fill(end_time);
+        await page.getByRole("button", {name: "Save"}).click();
+
+        await expect(page.getByText("Timelog saved")).toBeVisible();
+    }
+
     static async deleteTimelog(page: Page, timelog: string, taskName: string, taskID: string)
     {
         if(page.url() == HOST + "/task/edit/" + taskID + "#timelog") page.reload();


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [x] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: