### PR TITLE
Fix 2fa QR code image and secret not rendering

### DIFF
--- a/system/templates/vue-components/profile-security.vue.js
+++ b/system/templates/vue-components/profile-security.vue.js
@@ -122,8 +122,9 @@ Vue.component('profile-security', {
           return;
         }
 
-        _this.mfa_qr_code_url = response.data.qr_code;
-        _this.mfa_secret = response.data.mfa_secret;
+        const { data } = response.data;
+        _this.mfa_qr_code_url = data.qr_code;
+        _this.mfa_secret = data.mfa_secret;
       }).catch(function (error) {
         (new Toast("Failed to fetch QR Code")).show();
         console.log(error);


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

Fixes an issue where the 2fa qr code image and secret does not render.
![image](https://github.com/2pisoftware/cmfive-core/assets/46743919/dd305e6d-0bb5-4396-a0ac-409d67daeaf8)

This was caused by #271 where `AxiosResponse` was changed to `JsonResponse`, which causes the server to wrap the response data in a `data` key, and the vue component wasn't updated to accommodate.