### PR TITLE
Add time_type parameter to createTimelog utility function

### DIFF
--- a/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
+++ b/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
@@ -27,7 +27,7 @@ export class TimelogHelper  {
         await expect(page.getByText(timelog)).toBeVisible();
     }
 
-    static async createTimelog(page: Page, timelog: string, taskName: string, taskID: string, date: DateTime, start_time: string, end_time: string)
+    static async createTimelog(page: Page, timelog: string, taskName: string, taskID: string, date: DateTime, start_time: string, end_time: string, time_type: string = null)
     {
         if(page.url() != HOST + "/task/edit/" + taskID + "#details") {
             if(page.url() != HOST + "/task/tasklist")
@@ -52,9 +52,12 @@ export class TimelogHelper  {
         await page.locator("#time_start").fill(start_time);
         await page.locator("#time_end").fill(end_time);
         await page.getByLabel("Description", {exact: true}).fill(timelog);
+        if (time_type) {
+            await page.getByRole("combobox", {name: 'Task time' }).selectOption({ value: time_type });
+        }
         await page.locator("#timelog_edit_form").getByRole("button", { name: "Save" }).click();
 
-        await page.getByRole("link", {name: taskName, exact: true}).first().click();
+        await page.getByRole("link", {name: taskName, exact: false}).first().click();
         await page.getByRole("link", {name: "Time Log"}).click();
         await page.reload();
         await expect(page.getByText(timelog)).toBeVisible();


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [ ] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: