### PR TITLE
HTML form gen fix crash when `required` prop is not defined

### DIFF
--- a/system/classes/HtmlBootstrap5.php
+++ b/system/classes/HtmlBootstrap5.php
@@ -143,7 +143,12 @@ class HtmlBootstrap5 extends Html
                                 break;
                         }
                         if ((property_exists($field, "type") && $field->type !== "hidden") || !property_exists($field, "type")) {
-                            $buffer .= '<div class="col"><label class="' . $label_class . '"' . (property_exists($field, 'id') && !empty($field->id) ? ' for="' . $field->id . '"' : '') . '>' . $field->label . ($field->required ? " <small>Required</small>" : "") . "</label>"
+                            $buffer .= '<div class="col"><label class="' . $label_class . '"'
+									. (property_exists($field, 'id') && !empty($field->id) ? ' for="' . $field->id . '"' : '')
+									. '>'
+									. $field->label
+									. (property_exists($field, "required") && $field->required ? " <small>Required</small>" : "")
+									. "</label>"
                                 . $field->__toString() . '</div>';
                         } else {
                             $buffer .= $field->__toString();


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

Dalton found a crash in the AEC modules where a html form was being generated but `$field->required` wasn't defined and the generator doesn't check it exists before accessing it.

This has been tested by Dalton and I on my local system and the dev aec instance

<!-- List your changes as a dot point list. -->
## Changelog

- Added a check for if the property exists before accessing it.

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: 