### PR TITLE
Simplify timelog deduplication verification in `createTimelog` utility function

### DIFF
--- a/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
+++ b/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
@@ -54,16 +54,14 @@ export class TimelogHelper  {
         await page.getByLabel("Description", {exact: true}).fill(timelog);
         await page.locator("#timelog_edit_form").getByRole("button", { name: "Save" }).click();
 
-        if (check_duplicate) {
-            await expect(page.getByText("Duplicate Timelog Removed")).toBeVisible();
-        }
         await page.getByRole("link", {name: taskName, exact: false}).first().click();
         await page.getByRole("link", {name: "Time Log"}).click();
         await page.reload();
-        if (!check_duplicate) {
-            await expect(page.getByText(timelog)).toBeVisible();
-        } else {
+
+        if (check_duplicate) {
             await expect(page.getByText(timelog)).toBeHidden();
+        } else {
+            await expect(page.getByText(timelog)).toBeVisible();
         }
     }
 


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [x] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: