### PR TITLE
changes to test to log out timelogs that should be deduped but aren't…

### DIFF
--- a/system/modules/timelog/tests/acceptance/playwright/timelog.test.ts
+++ b/system/modules/timelog/tests/acceptance/playwright/timelog.test.ts
@@ -92,6 +92,7 @@ test("Test that duplicate timelogs are deleted" , async ({page}) => {
         "1:00",
         "2:00",
         true,
+        timelog1
     );
 
     await TimelogHelper.deleteTimelog(page, timelog1, task, taskID);

--- a/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
+++ b/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
@@ -65,9 +65,11 @@ export class TimelogHelper  {
             console.log(otherTimelogTrHtmlContent);
 
             const thisTimelogPreElement = await page.$(`tr > td > pre:has-text("${timelog}")`);
-            const thisTimelogTrElement = await thisTimelogPreElement.evaluateHandle(node => node.closest('tr'));
-            const thisTimelogTrHtmlContent = await thisTimelogTrElement.innerHTML();
-            console.log(thisTimelogTrHtmlContent);
+            if(thisTimelogPreElement) {
+                const thisTimelogTrElement = await thisTimelogPreElement.evaluateHandle(node => node.closest('tr'));
+                const thisTimelogTrHtmlContent = await thisTimelogTrElement.innerHTML();
+                console.log(thisTimelogTrHtmlContent);
+            }
 
             await expect(page.getByText(timelog)).toBeHidden();
         } else {

--- a/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
+++ b/system/modules/timelog/tests/acceptance/playwright/timelog.utils.ts
@@ -27,7 +27,7 @@ export class TimelogHelper  {
         await expect(page.getByText(timelog)).toBeVisible();
     }
 
-    static async createTimelog(page: Page, timelog: string, taskName: string, taskID: string, date: DateTime, start_time: string, end_time: string, check_duplicate: boolean = false)
+    static async createTimelog(page: Page, timelog: string, taskName: string, taskID: string, date: DateTime, start_time: string, end_time: string, check_duplicate: boolean = false, develop_ci_other_timelog: string = "")
     {
         if(page.url() != HOST + "/task/edit/" + taskID + "#details") {
             if(page.url() != HOST + "/task/tasklist")
@@ -59,6 +59,16 @@ export class TimelogHelper  {
         await page.reload();
 
         if (check_duplicate) {
+            const otherTimelogPreElement = await page.$(`tr > td > pre:has-text("${develop_ci_other_timelog}")`);
+            const otherTimelogTrElement = await otherTimelogPreElement.evaluateHandle(node => node.closest('tr'));
+            const otherTimelogTrHtmlContent = await otherTimelogTrElement.innerHTML();
+            console.log(otherTimelogTrHtmlContent);
+
+            const thisTimelogPreElement = await page.$(`tr > td > pre:has-text("${timelog}")`);
+            const thisTimelogTrElement = await thisTimelogPreElement.evaluateHandle(node => node.closest('tr'));
+            const thisTimelogTrHtmlContent = await thisTimelogTrElement.innerHTML();
+            console.log(thisTimelogTrHtmlContent);
+
             await expect(page.getByText(timelog)).toBeHidden();
         } else {
             await expect(page.getByText(timelog)).toBeVisible();


### PR DESCRIPTION
… in develop test

<!-- Have you made sure the following is correct? -->
## Checklist
- [ ] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: