### PR TITLE
Change LogService call for dedupe CI/CD testing to be info instead of debug

### DIFF
--- a/system/modules/timelog/actions/edit.php
+++ b/system/modules/timelog/actions/edit.php
@@ -127,9 +127,9 @@ function edit_POST(Web $w)
             $timelogs_for_task_and_user[] = $existing_timelog;
         }
     }
-    LogService::getInstance($w)->debug("DEVELOP CI/CD TIMELOG DEDUPE TEST LOG ### CURRENT ### ID $timelog->id - DT START " . substr($timelog->dt_start, 0, 10) . " " . substr($timelog->dt_start, 11, 5));
+    LogService::getInstance($w)->info("DEVELOP CI/CD TIMELOG DEDUPE TEST LOG ### CURRENT ### ID $timelog->id - DT START " . substr($timelog->dt_start, 0, 10) . " " . substr($timelog->dt_start, 11, 5));
     foreach ($timelogs_for_task_and_user as $existing_timelog_for_task_and_user) {
-        LogService::getInstance($w)->debug("DEVELOP CI/CD TIMELOG DEDUPE TEST LOG ### EXISTING ### ID $existing_timelog_for_task_and_user->id - DT START " . gmdate('Y-m-d', strtotime($existing_timelog_for_task_and_user->getDateStart() . ' ' . $existing_timelog_for_task_and_user->getTimeStart())) . " " . gmdate('H:i', strtotime($existing_timelog_for_task_and_user->getTimeStart())));
+        LogService::getInstance($w)->info("DEVELOP CI/CD TIMELOG DEDUPE TEST LOG ### EXISTING ### ID $existing_timelog_for_task_and_user->id - DT START " . gmdate('Y-m-d', strtotime($existing_timelog_for_task_and_user->getDateStart() . ' ' . $existing_timelog_for_task_and_user->getTimeStart())) . " " . gmdate('H:i', strtotime($existing_timelog_for_task_and_user->getTimeStart())));
 
         if (gmdate('Y-m-d', strtotime($existing_timelog_for_task_and_user->getDateStart() . ' ' . $existing_timelog_for_task_and_user->getTimeStart())) == substr($timelog->dt_start, 0, 10) && gmdate('H:i', strtotime($existing_timelog_for_task_and_user->getTimeStart())) == substr($timelog->dt_start, 11, 5)) {
             $w->error('Duplicate Timelog Removed', $redirect ?: '/timelog');


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [ ] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: