### PR TITLE
Force logout if deleting own user

### DIFF
--- a/system/modules/admin/actions/userdel.php
+++ b/system/modules/admin/actions/userdel.php
@@ -1,12 +1,18 @@
 <?php
 function userdel_GET(Web $w) {
 	$w->pathMatch("id");
-	$user = AuthService::getInstance($w)->getObject("User",$w->ctx("id"));
+	$user = AuthService::getInstance($w)->getObject("User", $w->ctx("id"));
 	if ($user) {
 		$user->delete();
-		$w->msg("User ".$user->login." deleted.","/admin/users");
-	} else {
-		$w->error("User ".$w->ctx("id")." does not exist.","/admin/users");
-	}
 
+		if ($w->session('user_id') == $w->ctx("id")) {
+			// We deleted our own user, force logout
+			$w->sessionDestroy();
+			$w->redirect($w->localUrl("/auth/login"));
+		} else {
+			$w->msg("User " . $user->login . " deleted.", "/admin/users");
+		}
+	} else {
+		$w->error("User " . $w->ctx("id") . " does not exist.", "/admin/users");
+	}
 }


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.

<!-- Add a short description. -->
## Description

Closes #277.

Still a discussion to be had for whether or not admins should be able to delete the last admin account.