### PR TITLE
fix: fix issue with templates with bad code

### DIFF
--- a/system/modules/admin/actions/templates/edit.php
+++ b/system/modules/admin/actions/templates/edit.php
@@ -50,7 +50,7 @@ function edit_GET(Web $w)
                 "id|name" => "description",
                 "value" => $t->description,
                 "label" => "Description",
-            ]))->setOptions(["placeholder" => "Please provide a brief description of the template"]) //["", "textarea", "description", $t->description]
+            ]))->setOptions(["placeholder" => "Please provide a brief description of the template"])
         ],
     ];
 
@@ -63,15 +63,15 @@ function edit_GET(Web $w)
                 "id|name" => "template_title",
                 "value" => $t->template_title,
                 "maxlength" => 100
-            ])) //["", "textarea", "template_title", $t->template_title, 100, 1, false]
+            ]))
         ]
     ];
     $newForm["Template Body"] = [
         [
             (new \Html\Cmfive\CodeMirrorEditor([
                 "id|name" => "template_body",
-                "value" => $t->template_body,
-            ])) //->addToConfig(['extensions' => ['basicSetup'], 'parent' => 'template_body']) //["", "textarea", "template_body", $t->template_body, 60, 100, "codemirror"]
+                "value" => htmlspecialchars($t->template_body),
+            ]))
         ]
     ];
 

--- a/system/modules/admin/tests/acceptance/playwright/admin.test.ts
+++ b/system/modules/admin/tests/acceptance/playwright/admin.test.ts
@@ -175,6 +175,41 @@ test("Test that Cmfive Admin handles templates", async ({ page }) => {
     await expect(templateTestPage.getByText("Test Company")).toBeVisible();
 });
 
+test("Test that Cmfive Admin handles bad templates", async ({ page }) => {
+    test.setTimeout(GLOBAL_TIMEOUT);
+
+    await CmfiveHelper.login(page, "admin", "admin");
+
+    const template = CmfiveHelper.randomID("template_");
+    const templateID = await AdminHelper.createTemplate(page, template, "Admin", "Templates", [
+        "<link href=\"https://fonts.googleapis.com/css?family=Open+Sans\" rel=\"stylesheet\">",
+        "<style>",
+        "body {text-align: left;font-family: \"open sans' sans-serif;",
+        "    color: #2b286a;",
+        "}",
+        "</style>",
+        "<table width='100%' align='center' class='form-table' cellpadding='1'>",
+        "    <tr>",
+        "        <td colspan='2' style='border:none;'>",
+        "            <img width='400' src='' style='width: 400px;' />",
+        "        </td>",
+        "        <td colspan='2' style='border:none; text-align:right;'>",
+        "            Test Company<br/>",
+        "            123 Test St, Test Town, NSW 1234<br/>",
+        "            test@example.com<br/>",
+        "            ACN: 123456789<br/>",
+        "            ABN: 12345678901<br/>",
+        "        </td>",
+        "    </tr>",
+        "</table>",
+    ]);
+
+    await AdminHelper.viewTemplate(page, template, templateID);
+    await page.getByRole("link", {name: "Template"}).click();
+
+    await expect(await page.locator('.cm-line')).toHaveCount(22);
+});
+
 test("Test that Cmfive Admin can create/run/rollback migrations", async ({ page }) => {
     test.setTimeout(GLOBAL_TIMEOUT);
     CmfiveHelper.acceptDialog(page);

--- a/system/modules/admin/tests/acceptance/playwright/admin.utils.ts
+++ b/system/modules/admin/tests/acceptance/playwright/admin.utils.ts
@@ -277,6 +277,16 @@ export class AdminHelper {
         return page.url().split("/admin-templates/edit/")[1].split("#")[0];
     }
 
+    static async viewTemplate(page: Page, templateTitle: string, templateID: string): Promise<void>
+    {
+        if (page.url() != HOST + "/admin-templates/edit/" + templateID + "#details") {
+            if(page.url() != HOST + "/admin-templates")
+                await CmfiveHelper.clickCmfiveNavbar(page, "Admin", "Templates");
+
+            await CmfiveHelper.getRowByText(page, templateTitle).getByRole("button", {name: "Edit"}).click();
+        }
+    }
+
     static async demoTemplate(page: Page, templateTitle: string, templateID: string): Promise<Page>
     {
         if(page.url() != HOST + "/admin-templates/edit/" + templateID + "#details") {


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.

<!-- Add a short description. -->
## Description
Fixes an issue where non-matching quotes escape the CodeMirror editor. 
### Note that this fix _may_ cause certain types of quotes to show up as ```&quot;``` and these will need to be fixed before you save the template

<!-- List your changes as a dot point list. -->
## Changelog
- Fix issue with non-matching quotes breaking CodeMirror
- Added tests

<!-- Add any important refs or issues numbers. -->
refs:
issues: