### PR TITLE
Fix/migration dropouts

### DIFF
--- a/system/modules/admin/install/migrations/20190117125821-AdminAddMigrationMessageTextColumns.php
+++ b/system/modules/admin/install/migrations/20190117125821-AdminAddMigrationMessageTextColumns.php
@@ -1,28 +1,39 @@
 <?php
 
-class AdminAddMigrationMessageTextColumns extends CmfiveMigration {
+class AdminAddMigrationMessageTextColumns extends CmfiveMigration
+{
 
-	public function up() {
-		$this->addColumnToTable('migration', 'pretext', 'string', ['default' => null, 'null' => true]);
-		$this->addColumnToTable('migration', 'posttext', 'string', ['default' => null, 'null' => true]);
-		$this->addColumnToTable('migration', 'description', 'string', ['default' => null, 'null' => true]);
+	public function up()
+	{
+
+		if ($this->hasTable('migration') && !$this->table("migration")->hasColumn("pretext")) {
+			$this->addColumnToTable('migration', 'pretext', 'string', ['default' => null, 'null' => true]);
+			$this->addColumnToTable('migration', 'posttext', 'string', ['default' => null, 'null' => true]);
+			$this->addColumnToTable('migration', 'description', 'string', ['default' => null, 'null' => true]);
+		}
 	}
 
-	public function down() {
-		$this->removeColumnFromTable('migration', 'pretext');
-		$this->removeColumnFromTable('migration', 'posttext');
-		$this->removeColumnFromTable('migration', 'description');
+	public function down()
+	{
+		if ($this->hasTable('migration') && $this->table("migration")->hasColumn("pretext")) {
+			$this->removeColumnFromTable('migration', 'pretext');
+			$this->removeColumnFromTable('migration', 'posttext');
+			$this->removeColumnFromTable('migration', 'description');
+		}
 	}
 
-	public function preText() {
+	public function preText()
+	{
 		return "";
 	}
 
-	public function postText() {
+	public function postText()
+	{
 		return "";
 	}
 
-	public function description() {
+	public function description()
+	{
 		return "";
 	}
 }

--- a/system/modules/admin/install/migrations/20240218223900-InboxRemoveTable.php
+++ b/system/modules/admin/install/migrations/20240218223900-InboxRemoveTable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Removes the inbox table from the Inbox module that is no longer used or supported.
  */
@@ -12,17 +13,16 @@ class InboxRemoveTable extends CmfiveMigration
         $this->dropTable('inbox_message');
 
         //Clear out the related user roles
-		if ($this->hasTable('user_role')) {
+        if ($this->hasTable('user_role')) {
             $this->w->db->delete('user_role')->where('role', 'inbox_sender')->execute();
             $this->w->db->delete('user_role')->where('role', 'inbox_reader')->execute();
         }
     }
 
-    public function down(): void
-    {
-    }
+    public function down(): void {}
 
-    public function description() {
+    public function description()
+    {
         return 'Remove inbox table and roles';
     }
 }

--- a/system/modules/admin/install/migrations/20240218223900-InboxRemoveTable.php
+++ b/system/modules/admin/install/migrations/20240218223900-InboxRemoveTable.php
@@ -12,8 +12,10 @@ class InboxRemoveTable extends CmfiveMigration
         $this->dropTable('inbox_message');
 
         //Clear out the related user roles
-        $this->w->db->delete('user_role')->where('role', 'inbox_sender')->execute();
-        $this->w->db->delete('user_role')->where('role', 'inbox_reader')->execute();
+		if ($this->hasTable('user_role')) {
+            $this->w->db->delete('user_role')->where('role', 'inbox_sender')->execute();
+            $this->w->db->delete('user_role')->where('role', 'inbox_reader')->execute();
+        }
     }
 
     public function down(): void

--- a/system/modules/admin/install/migrations/20240911010101-AdminStableMigrationSchema.php
+++ b/system/modules/admin/install/migrations/20240911010101-AdminStableMigrationSchema.php
@@ -1,0 +1,34 @@
+<?php
+
+class AdminStableMigrationSchema extends CmfiveMigration
+{
+
+    public function up()
+    {
+        $this->addColumnToTable('migration', 'pretext', 'string', ['default' => null, 'null' => true]);
+        $this->addColumnToTable('migration', 'posttext', 'string', ['default' => null, 'null' => true]);
+        $this->addColumnToTable('migration', 'description', 'string', ['default' => null, 'null' => true]);
+    }
+
+    public function down()
+    {
+        $this->removeColumnFromTable('migration', 'pretext');
+        $this->removeColumnFromTable('migration', 'posttext');
+        $this->removeColumnFromTable('migration', 'description');
+    }
+
+    public function preText()
+    {
+        return "";
+    }
+
+    public function postText()
+    {
+        return "";
+    }
+
+    public function description()
+    {
+        return "";
+    }
+}

--- a/system/modules/admin/models/MigrationService.php
+++ b/system/modules/admin/models/MigrationService.php
@@ -549,7 +549,8 @@ MIGRATION;
     {
         $filenames = [
             "AdminInitialMigration" => "20151030134124-AdminInitialMigration.php",
-            "AdminMigrationSeed" => "20170123091600-AdminMigrationSeed.php"
+            "AdminMigrationSeed" => "20170123091600-AdminMigrationSeed.php",
+            "AdminStableMigrationSchema" => "20240911010101-AdminStableMigrationSchema.php",
         ];
 
         $directory = SYSTEM_MODULE_DIRECTORY . DS . "admin" . DS . MIGRATION_DIRECTORY;


### PR DESCRIPTION
## Description
Be sure migration table schema is conformed on any new/clean deployment

## Changelog
add rich fields to the 'hard coded' (pre)installation admin migrations, so migration table always has full fields supported on new/clean installs
patch 20190117125821-AdminAddMigrationMessageTextColumns.php for if-not-exists-column etc

issues: https://github.com/2pisoftware/cmfive-core/issues/349
