### PR TITLE
fix: aws-sdk, Free default lowest at safe version

### DIFF
--- a/system/modules/admin/config.php
+++ b/system/modules/admin/config.php
@@ -30,7 +30,7 @@ Config::set('admin', [
         "sendgrid/sendgrid" => "^8.0.0",
         "softark/creole" => "~1.2",
         "monolog/monolog" => "^1.22",
-        "aws/aws-sdk-php" => "3.224",
+        "aws/aws-sdk-php" => "^3.288",
         "aws/aws-php-sns-message-validator" => "^1.1",
         "maxbanton/cwh" => "^1.0"
     ],


### PR DESCRIPTION

## Description
Make sure module effort to require aws-sdk is always above known (Guzzle)CVE