### PR TITLE
Fix: Change to mount instead of install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,23 @@ jobs:
             fi
           done
 
+      - name: Get source code details
+        if: ${{ failure() }} || ${{ success() }}
+        run: |
+          echo ">> CONTAINER LABELS (BOILERPLATE) <<"
+          echo "===================================="
+          docker inspect --format='{{range $key, $value := .Config.Labels}}{{$key}}={{$value}}{{println}}{{end}}' cmfive
+          echo ""
+          echo ""
+          echo ">> CORE COMMIT DETAILS <<"
+          echo "========================="
+          echo "VENDOR DIRECTORY: (should be unused)"
+          docker exec -u cmfive cmfive sh -c "cd composer/vendor/2pisoftware/cmfive-core && git log -n 1"
+          echo ""
+          echo "MOUNTED CORE: (should be used, this is mounted to /system)"
+          pushd core
+          git log -n 1
+
       - name: Compile the theme
         run: |
           # Copy the theme from the docker container
@@ -280,22 +297,6 @@ jobs:
             if [ $? -gt 0 ]; then
                 echo "Timelog module tests failed"
             fi
-
-      - name: Get source code details
-        if: ${{ failure() }} || ${{ success() }}
-        run: |
-          echo ">> CONTAINER LABELS (BOILERPLATE) <<"
-          echo "===================================="
-          docker inspect --format='{{range $key, $value := .Config.Labels}}{{$key}}={{$value}}{{println}}{{end}}' cmfive
-          echo ""
-          echo ""
-          echo ">> CORE COMMIT DETAILS <<"
-          echo "========================="
-          echo "VENDOR DIRECTORY: (should be unused)"
-          docker exec -u cmfive cmfive sh -c "cd composer/vendor/2pisoftware/cmfive-core && git log -n 1"
-          echo "MOUNTED CORE: (should be used)"
-          pushd core
-          git log -n 1
                 
       - name: Get container logs
         if: ${{ failure() }} || ${{ success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,11 +129,11 @@ jobs:
             -v ${{ github.workspace }}/boilerplate/.codepipeline/test_agent/configs/test_agent-config.php:/var/www/html/config.php:rw \
             -v ${{ github.workspace }}/boilerplate/test:/var/www/html/test:rw \
             -v ${{ github.workspace }}/boilerplate/storage:/var/www/html/storage:rw \
+            -v ${{ github.workspace }}/core/system:/var/www/html/system:rw \
             -e DB_HOST=mysql-8 \
             -e DB_USERNAME=$DB_USERNAME \
             -e DB_PASSWORD=$DB_PASSWORD \
             -e DB_DATABASE=$DB_DATABASE \
-            -e INSTALL_CORE_BRANCH=$CORE_BRANCH \
             -e ENVIRONMENT=development \
             --network=cmfive \
             $BOILERPLATE_IMAGE
@@ -291,7 +291,11 @@ jobs:
           echo ""
           echo ">> CORE COMMIT DETAILS <<"
           echo "========================="
+          echo "VENDOR DIRECTORY: (should be unused)"
           docker exec -u cmfive cmfive sh -c "cd composer/vendor/2pisoftware/cmfive-core && git log -n 1"
+          echo "MOUNTED CORE: (should be used)"
+          pushd core
+          git log -n 1
                 
       - name: Get container logs
         if: ${{ failure() }} || ${{ success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,11 +162,11 @@ jobs:
           echo ">> CORE COMMIT DETAILS <<"
           echo "========================="
           echo "VENDOR DIRECTORY: (should be unused)"
-          docker exec -u cmfive cmfive sh -c "cd composer/vendor/2pisoftware/cmfive-core && git log -n 1"
+          docker exec -u cmfive cmfive sh -c "cd composer/vendor/2pisoftware/cmfive-core && git log -1 --pretty=format:"CORE_HASH=\"%H\"%nCORE_COMMIT_MSG=\"%s\"%nCORE_REF=\"%D\"""
           echo ""
           echo "MOUNTED CORE: (should be used, this is mounted to /system)"
           pushd core
-          git log -n 1
+          git log -1 --pretty=format:"CORE_HASH=\"%H\"%nCORE_COMMIT_MSG=\"%s\"%nCORE_REF=\"%D\""
 
       - name: Compile the theme
         run: |


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [ ] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: