### PR TITLE
fix: fix issue with status field failing on tasks on new versions of Chrome/Edge

### DIFF
--- a/system/modules/task/templates/edit.tpl.php
+++ b/system/modules/task/templates/edit.tpl.php
@@ -187,7 +187,7 @@
                     $('#task_type').val('');
                     $('#priority').parent().html(result[1]);
                     $('#assignee_id').parent().html(result[2]);
-                    $('#status').html(result[4])
+                    $('#status').parent().html(result[4])
                 }
                 $('#tasktext').html(result[3]);
                 $("#tasktext").fadeIn();


### PR DESCRIPTION
<!-- Add a short description. -->
## Description
This fix fixes a very old bug that browsers historically seemed to just be okay with. They aren't now and it needs to be pushed through. Here is the issue on our CRM:
![image](https://github.com/user-attachments/assets/f85b27c4-b31d-4d6f-a87c-19c9f314dae8)

And here is the issue fixed locally:
![image](https://github.com/user-attachments/assets/c06891c9-8343-4672-bf1c-df12c7179404)

<!-- List your changes as a dot point list. -->
## Changelog
- Fix issue with jQuery not selecting parent element when replacing status field

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information
This is directly affecting us and clients so it is imperative that this is fixed today.

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: